### PR TITLE
Support for page titles that will show in the GDS typography standard…

### DIFF
--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsDetailsForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsDetailsForm.php
@@ -28,7 +28,7 @@ class ParPartnershipFlowsDetailsForm extends ParBaseForm {
     $par_data_partnership = $this->getRouteParam('par_data_partnership');
     if ($par_data_partnership) {
       $par_data_organisation = current($par_data_partnership->getOrganisation());
-      return $par_data_organisation->get('organisation_name')->getString();
+      return "Primary Authority partnership information | {$par_data_organisation->get('organisation_name')->getString()}";
     }
 
     return parent::titleCallback();

--- a/web/themes/custom/par_theme/templates/page-title.html.twig
+++ b/web/themes/custom/par_theme/templates/page-title.html.twig
@@ -15,7 +15,25 @@
 <!-- page-title.html.twig -->
 {{ title_prefix }}
 {% if title %}
-  <h1{{ title_attributes.addClass('heading-xlarge') }}>{{ title }}</h1>
+  <h1{{ title_attributes.addClass('heading-xlarge') }}>
+    {# Handle views page titles doing something completely different! #}
+    {% if title['#markup'] %}
+      {% set page_title = title['#markup']|e %}
+    {% else %}
+      {% set page_title = title|e %}
+    {% endif %}
+
+    {% if '|' in page_title %}
+      {% set page_title_parts = page_title | split('|') %}
+    {% endif %}
+
+    {% if page_title_parts %}
+      <span class="heading-secondary">{{ page_title_parts | first | trim }}</span>
+      {{ page_title_parts | last | trim }}
+    {% else %}
+      {{ title }}
+    {% endif %}
+  </h1>
 {% endif %}
 {{ title_suffix }}
 <!-- ends page-title.html.twig -->


### PR DESCRIPTION
As per https://govuk-elements.herokuapp.com/typography/, supporting page titles with the Drupal-esque page title pipe (|) as a divider.

Will work with views and page titles set by controllers, forms etc.

<img width="1144" alt="primary_authority_partnership_information___abcd_mart___primary_authority_register" src="https://user-images.githubusercontent.com/150512/32316821-a73ba3ae-bfa9-11e7-8db5-3e79e4b77e6f.png">

<img width="634" src="https://user-images.githubusercontent.com/150512/32316837-b4e603dc-bfa9-11e7-8bf2-bee5bbb26f2d.png">

<img width="712" src="https://user-images.githubusercontent.com/150512/32316847-c04995ae-bfa9-11e7-82f4-cb8c98ca8a02.png">
