### PR TITLE
Vagrant should run as host uid/gid for file permissions.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,15 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 8111, host: 8111
   config.vm.network "forwarded_port", guest: 5411, host: 5411
 
-  config.vm.synced_folder ".", "/vagrant", type: "nfs"
+  host_user_id = Process.uid
+  host_group_id = Process.gid
+
+  if (/darwin/ =~ RUBY_PLATFORM) != nil
+    config.vm.synced_folder ".", "/vagrant", nfs: true, :bsd__nfs_options => ["mapall=#{host_user_id}:#{host_group_id}"]
+  else
+    config.vm.synced_folder ".", "/vagrant", nfs: true, :linux__nfs_options => ["no_root_squash"]
+  end
+
   config.vm.provision "shell", inline: $script
   config.vm.provision :shell, :inline => "sudo rm /etc/localtime && sudo ln -s /usr/share/zoneinfo/Europe/London /etc/localtime", run: "always"
 

--- a/docker/destroy-dependencies.sh
+++ b/docker/destroy-dependencies.sh
@@ -1,7 +1,3 @@
-rm -rf ../vendor
-rm -rf ../node_modules
-rm -rf ../tests/node_modules
 if [ -f ../web/sites/default/settings.local.php ]; then
   rm ../web/sites/default/settings.local.php
 fi
-

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -8,8 +8,8 @@
 # Install dependencies
 
     docker exec -i par_beta_web bash -c 'su - composer -c "cd ../../var/www/html && php composer.phar install"'
-    docker exec -i par_beta_web bash -c "cd /var/www/html/tests && rm -rf node_modules/* && ../../../../usr/local/n/versions/node/7.2.1/bin/npm install"
-    docker exec -i par_beta_web bash -c "rm -rf node_modules/* && ../../../usr/local/n/versions/node/7.2.1/bin/npm install"
+    docker exec -i par_beta_web bash -c "cd /var/www/html/tests && ../../../../usr/local/n/versions/node/7.2.1/bin/npm install"
+    docker exec -i par_beta_web bash -c "../../../usr/local/n/versions/node/7.2.1/bin/npm install"
     docker exec -i par_beta_web bash -c "../../../usr/local/n/versions/node/7.2.1/bin/npm run gulp"
 
 # Setup the development settings file:


### PR DESCRIPTION
To keep in line with our Docker on Travis, I have implemented an NFS uid/gid flag for OS X. It is untested on Linux though, so would be good to make sure it works on Linux as well with the flag I found. (BSD NFS vs Linux NFS)

What this does improve is now there shouldn't be a need to delete any system files or clone the repo again or use any handy scripts.

It will speed up vagrant build and also at any time you can now run `vagrant up --provision` to get a clean Drupal instance (with a new database et al)

