### PR TITLE
Views to support the GDS split titles

### DIFF
--- a/web/themes/custom/par_theme/templates/page-title.html.twig
+++ b/web/themes/custom/par_theme/templates/page-title.html.twig
@@ -17,13 +17,13 @@
 {% if title %}
   <h1{{ title_attributes.addClass('heading-xlarge') }}>
     {# Handle views page titles doing something completely different! #}
-    {% if title['#markup'] %}
+    {% if title is iterable %}
       {% set page_title = title['#markup'] %}
     {% else %}
       {% set page_title = title %}
     {% endif %}
 
-    {% if '|' in page_title %}
+    {% if '|' in page_title|e %}
       {% set page_title_parts = page_title | split('|') %}
     {% endif %}
 


### PR DESCRIPTION
Even though most views seem to have had their titles changes either not merged in or purposefully reverted, it now supports GDS split titles again.

*testing notes*
1. edit a view title to have "First bit of title | Second bit of title"
2. view page to confirm title looks like as intended below.

<img width="1029" alt="messages image 3434094047" src="https://user-images.githubusercontent.com/150512/33267228-9c33b32c-d370-11e7-9231-a2cc280b2b88.png">
