### PR TITLE
docker-sync for mac os x based Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 node_modules/
 npm-debug.log
 
+# Docker sync.
+docker/.docker-sync/
+
 # Exclude the main drupal scaffold files.
 # If we want to make changes to any of these files
 # we must first remove them from gitignore and

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,92 +1,30 @@
 ## Docker Development Environment
 
-### Prep
-
-If you've not got your key installed already, add your private key:
-
-    ssh-agent bash
-    ssh-add /path/to/private/key/file
-    
-Install [docker](https://docs.docker.com/engine/installation/linux/ubuntu/) (or [Docker for Windows](https://docs.docker.com/docker-for-windows/install/), or [Docker for Mac](https://docs.docker.com/docker-for-mac/install/)), then:
-
-    cd docker
-    sh setup.sh
-    
-Request the hash salt from another member of the team and add this to the hash setting at the bottom of your local settings file:
-
-    vi ../web/sites/default/settings.local.php
-    
-You can then visit the site at:
-
-    http://127.0.0.1:8111
-
-### Ubuntu users
-
-You'll need to run setup as root
-    
-    sudo sh reset.sh
-    
-### Windows users
-
-The recommended method for installing on Windows is to use a Git Bash.
-
 ### Mac users
 
-To speed up file synching between the web container and your host, you will need to use docker-sync. Docker for Mac is considerably (~50x) slower maintaining the link between host and container files.
+To speed up file sync between the web container and your host, you will need to use docker-sync. Docker for Mac is considerably (~50x) slower maintaining the link between host and container files.
 
 After following the setup steps above, run the following:
 
     sudo gem install docker-sync
     docker-sync-start start
-    
-### Docker setup troubleshooting
 
-If the installation appears to be stalled, check that you are not connected to a public WiFi such as "_The Cloud" as these often block certain ports that are used by docker-compose.
+### Installation
 
-### When switching branches
+    sudo gem install docker-sync
 
-To reinstall dependencies and update Drupal:
+### Sync stop/stop/restart
 
-    sh refresh-dependencies.sh
+    docker-sync start
+    docker-sync stop
+    docker-sync clean
+    docker-sync list
 
-# Cucumberjs/Webdriverio (e2e acceptance testing)
+### View sync log
 
-## How to run the tests
+    cd docker
+    tail -f .docker-sync/daemon.log
 
-To run your tests just call the [WDIO runner](http://webdriver.io/guide/testrunner/gettingstarted.html):
-
-    docker exec -ti par_beta_web bash -c "cd tests && ./node_modules/.bin/wdio wdio.BUILD.conf.js"
-
-Environments available are: DEV (Chrome), BUILD (PhantonJS). DEV won't work when running the application using the Docker containers.
-
-## Running single feature
-Sometimes its useful to only execute a single feature file, to do so use the following command:
-
-    docker exec -ti par_beta_web bash -c "cd tests && ./node_modules/.bin/wdio --spec src/features/beis.feature wdio.BUILD.conf.js"
-        
-## Some useful commands
-
-### Database client
-
-    docker exec -it postgresql sudo -u postgres psql
-    
-### Raw database dump
-
-    docker exec -i par_beta_db pg_dump -U par par > pg_dump.sql
-    
-### Drush dump
-
-    docker exec -i par_beta_web  /var/www/html/vendor/bin/drush sql-dump @dev --root=/var/www/html/web --result-file=/var/www/html/docker/fresh_drupal_postgres.sql --structure-tables-key=common --skip-tables-key=common
-    
-### Drush import
-
-    docker exec -i par_beta_web  /var/www/html/vendor/bin/drush sql-cli @dev --root=/var/www/html/web < fresh_drupal_postgres.sql
-
-### Destroy containers and images and rebuild
+## Destroy containers and images and rebuild
 
     docker rm --force `docker ps -qa` && docker rmi $(docker images -q) && docker-compose up -d --force-recreate --build && sh setup.sh
-
-    
-
-
-

--- a/docker/docker-compose-mac.yml
+++ b/docker/docker-compose-mac.yml
@@ -1,0 +1,27 @@
+version: "2"
+
+services:
+  web:
+    image: parbeta/web:v9
+    container_name: par_beta_web
+    links:
+      - db
+    ports:
+      - "8111:80"
+    volumes:
+      - docker-mac-sync:/var/www/html:nocopy
+
+  db:
+    container_name: par_beta_db
+    restart: always
+    image: postgres:9.6.3
+    ports:
+      - "5411:5432"
+    environment:
+      POSTGRES_USER: par
+      POSTGRES_PASSWORD: 123456
+      POSTGRES_DB: par
+
+volumes:
+  docker-mac-sync:
+    external: true

--- a/docker/docker-sync.yml
+++ b/docker/docker-sync.yml
@@ -1,0 +1,14 @@
+version: "2"
+
+options:
+  verbose: true
+syncs:
+  #IMPORTANT: ensure this name is unique and does not match your other container names
+  docker-mac-sync:
+    src: '../'
+    sync_strategy: 'unison'
+    sync_args:
+          - "-prefer newer"
+          - "-ignore='Path .git'"
+          - "-ignore='BelowPath .git'"
+    sync_excludes: ['.git*', '.DS_Store', '.docker*', 'docker*yml', 'Dockerfile*', '.idea']

--- a/docker/reconfigure.sh
+++ b/docker/reconfigure.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Install dependencies
+
+    docker exec -i par_beta_web bash -c 'su - composer -c "php composer.phar install"'
+    docker exec -i par_beta_web bash -c "cd /var/www/html/tests && npm install"
+    docker exec -i par_beta_web bash -c "npm install"
+    docker exec -i par_beta_web bash -c "npm run gulp"
+
+# Load the test data:
+    DATAFILE=drush-dump-production-sanitized-latest.sql
+
+    docker exec -i par_beta_web bash -c "cd web && ../vendor/bin/drush fsg s3backups $DATAFILE.tar.gz /dump.sql.tar.gz && cd / && tar --no-same-owner -zxvf dump.sql.tar.gz"
+
+    docker exec -i par_beta_web bash -c "vendor/bin/drush @dev --root=/var/www/html/web sql-drop -y"
+
+    docker exec -i par_beta_web bash -c "cd web && ../vendor/bin/drush sql-cli @dev --root=/var/www/html/web < /$DATAFILE && rm /$DATAFILE"
+
+    docker exec -i par_beta_web bash -c "cd web && ../vendor/bin/drush cc drush"
+
+# Update Drupal
+
+    docker exec -i par_beta_web bash -c "sh drupal-update.sh /var/www/html"

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -8,9 +8,9 @@
 # Install dependencies
 
     docker exec -i par_beta_web bash -c 'su - composer -c "cd ../../var/www/html && php composer.phar install"'
-    docker exec -i par_beta_web bash -c "cd /var/www/html/tests && ../../../../usr/local/n/versions/node/7.2.1/bin/npm install"
-    docker exec -i par_beta_web bash -c "../../../usr/local/n/versions/node/7.2.1/bin/npm install"
-    docker exec -i par_beta_web bash -c "../../../usr/local/n/versions/node/7.2.1/bin/npm run gulp"
+    docker exec -i par_beta_web bash -c "cd /var/www/html/tests && npm install"
+    docker exec -i par_beta_web bash -c "npm install"
+    docker exec -i par_beta_web bash -c "npm run gulp"
 
 # Setup the development settings file:
 


### PR DESCRIPTION
This allows you to use Docker for Mac (without Vagrant). This would need thorough testing. README may help