### PR TITLE
New Vagrant box and a helper script for rebuilding the environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,29 +1,19 @@
 $script = <<SCRIPT
-echo I am provisioning...
-date > /etc/vagrant_provision_start
-
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-sudo apt-get update -y
-apt-cache policy docker-ce
-sudo apt-get install -y docker-ce
-sudo apt-get install -y docker-compose
-sudo adduser ubuntu docker
-newgrp docker
-
 cd /vagrant/docker
 sudo docker-compose up -d
 
 sh setup.sh
-
-date > /etc/vagrant_provision_end
 SCRIPT
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "netsensia/xenial64-docker"
+  config.vm.box_version = "1.0.0"
   config.vm.network "private_network", ip: "192.168.82.68"
   config.vm.network "forwarded_port", guest: 8111, host: 8111
   config.vm.network "forwarded_port", guest: 5411, host: 5411
+
+  config.ssh.username = "ubuntu"
+  config.ssh.password = "vagrant"
 
   host_user_id = Process.uid
   host_group_id = Process.gid
@@ -40,5 +30,6 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |v|
     v.memory = 3096
     v.cpus = 4
+    v.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
   end
 end

--- a/docker/destroy-dependencies.sh
+++ b/docker/destroy-dependencies.sh
@@ -1,3 +1,0 @@
-if [ -f ../web/sites/default/settings.local.php ]; then
-  rm ../web/sites/default/settings.local.php
-fi

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -3,7 +3,9 @@
 # Destroy dependencies
 
     cd /vagrant/docker
-    sudo sh destroy-dependencies.sh
+    if [ -f ../web/sites/default/settings.local.php ]; then
+        sudo rm ../web/sites/default/settings.local.php
+    fi
 
 # Install dependencies
 

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -1,10 +1,33 @@
 # Run this command in the directory above the repo and Have a copy of your .env file in that directory
 #
-# sh beis-primary-authority-register/vagrant.sh
+# sh <repo directory>/vagrant.sh [branch]
 #
 
+command -v php >/dev/null 2>&1 || { 
+    echo "################################################################################################"
+    echo >&2 "PHP executable not found"
+    echo "################################################################################################"
+    exit 1 
+}
+
+command -v vagrant >/dev/null 2>&1 || { 
+    echo "################################################################################################"
+    echo >&2 "Vagrant executable not found"
+    echo "################################################################################################"
+    exit 1 
+}
+
+command -v git >/dev/null 2>&1 || { 
+    echo "################################################################################################"
+    echo >&2 "Git executable not found"
+    echo "################################################################################################"
+    exit 1 
+}
+
+IFS="/" read -ra REPO_DIR <<< "$0"
+
 # Into the repo
-cd beis-primary-authority-register
+cd $REPO_DIR
 
 # Save a copy of the .env file for later
 cp .env ..
@@ -17,13 +40,16 @@ sudo lsof -ti:8111 | xargs kill
 
 # Up above the repo for the deletion
 cd ..
-rm -rf beis-primary-authority-register
+rm -rf $REPO_DIR
 
 # Clone the repo
-git clone git@github.com:UKGovernmentBEIS/beis-primary-authority-register
+git clone git@github.com:UKGovernmentBEIS/beis-primary-authority-register $REPO_DIR
 
 # Into the repo
-cd beis-primary-authority-register
+cd $REPO_DIR
+
+# Checkout the required branch, or default to master if none specified
+if [ -z $1 ]; then git checkout $1; fi
 
 # Get the .env file we saved earlier
 cp ../.env .

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -1,0 +1,37 @@
+# Run this command in the directory above the repo and Have a copy of your .env file in that directory
+#
+# sh beis-primary-authority-register/vagrant.sh
+#
+
+# Into the repo
+cd beis-primary-authority-register
+
+# Save a copy of the .env file for later
+cp .env ..
+
+# Destroy
+vagrant destroy
+
+# Belt and braces, kill the process listening on port 8111, if any
+sudo lsof -ti:8111 | xargs kill
+
+# Up above the repo for the deletion
+cd ..
+rm -rf beis-primary-authority-register
+
+# Clone the repo
+git clone git@github.com:UKGovernmentBEIS/beis-primary-authority-register
+
+# Into the repo
+cd beis-primary-authority-register
+
+# Get the .env file we saved earlier
+cp ../.env .
+
+# Compose and fix permissions
+php composer.phar install
+chmod -R 777 web/modules/contrib
+
+# Bring up the VM
+vagrant up
+


### PR DESCRIPTION
To test this:

1. Checkout the branch
2. cd ..
3. Add a line to vagrant.sh to checkout the branch after it clones the repo
4. sh beis-primary-authority-register/vagrant.sh

The new Vagrant box differs only in that it has all the Docker packages pre-installed.

The new vagrant.sh file must be run from the directory above the repo. It will do a few helpful things

1) Save your environment file
2) Destroy the VM and clear away conflicting processes
3) Install Composer dependencies on the host and the fix the permissions for the VM and Docker
