### PR TITLE
Write errors on latest Trusty build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@
 ### BUILD                                                                  ###
 ##############################################################################
 
+# Fix Travis write errors. These write errors occurred after
+# a Travis update to new Trusty images on Dec. 12th 2017. The reason for these
+# write errors is unknown. Using the deprecated builds did not fix the problem.
+# Setting 'filter_secrets: false' as suggested here
+# https://github.com/travis-ci/travis-ci/issues/4704#issuecomment-321777557
+# fixes the problem.
+filter_secrets: false
+
 language: php
 
 php:


### PR DESCRIPTION
Borrowed from some other open source projects, using this seems to be a workaround for the Travis stdout write-gate.