### PR TITLE
PAR-1059 & PAR-1062: Added pages for partnership revocation.

### DIFF
--- a/sync/par_flows.par_flow.revoke_partnership.yml
+++ b/sync/par_flows.par_flow.revoke_partnership.yml
@@ -1,0 +1,26 @@
+uuid: 289f26b0-bee0-4c2d-b12e-3cfe96c2546f
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: j-PPsyK85-2IXfj8Wlgf4SZoEwbNfQDOMqgOBWia0nM
+id: revoke_partnership
+label: 'Revoke Partnership'
+default_title: null
+default_section_title: null
+description: 'The revoke operations for a given partnership.'
+save_method: end
+steps:
+  1:
+    route: par_help_desks_flows.confirm_revoke_partnership
+    form_id: par_rd_help_desk_revoke_confirm
+    redirect:
+      next: 2
+      cancel: 3
+  2:
+    route: par_help_desks_flows.revoke_partnership
+    form_id: par_rd_help_desk_revoke
+    redirect:
+      done: 3
+  3:
+    route: view.helpdesk_dashboard.par_rd_helpdesk_dashboard_page

--- a/tests/src/features/92-partnerships-approval-helpdesk-user.feature
+++ b/tests/src/features/92-partnerships-approval-helpdesk-user.feature
@@ -22,7 +22,7 @@ Feature: Helpdesk approve partnership
         And I click on the button "#edit-next"
 
         # APPROVAL CONFIRMATION SCREEN
-        Then I expect that element "#edit-partnership-info" contains the text "Partnership is approved between"
+        Then I expect that element "#edit-partnership-info" contains the text "The following partnership has been approved"
         And I expect that element "#edit-partnership-info" contains the text "Business For Direct Partnership 1"
         And I click on the button "#edit-done"
 

--- a/web/modules/custom/par_data/src/Entity/ParDataAdvice.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataAdvice.php
@@ -65,6 +65,19 @@ use Drupal\Core\Field\BaseFieldDefinition;
 class ParDataAdvice extends ParDataEntity {
 
   /**
+   * {@inheritdoc}
+   */
+  public function revoke() {
+    // Only advice of type 'authority_advice' can be revoked.
+    if ($this->getRawStatus() === 'authority_advice') {
+      parent::revoke();
+    }
+    else {
+      $this->archive();
+    }
+  }
+
+  /**
    * Get the regulatory functions for this Advice.
    */
   public function getRegulatoryFunction() {

--- a/web/modules/custom/par_data/src/Entity/ParDataPartnership.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataPartnership.php
@@ -67,6 +67,28 @@ use Drupal\user\UserInterface;
 class ParDataPartnership extends ParDataEntity {
 
   /**
+   * {@inheritdoc}
+   *
+   * @param string $reason
+   *   The reason for revoking this partnership.
+   */
+  public function revoke($reason = '') {
+    // Revoke/archive all dependent entities as well.
+    $inspection_plans = $this->getInspectionPlan();
+    foreach ($inspection_plans as $inspection_plan) {
+      $inspection_plan->revoke();
+    }
+
+    $advice_documents = $this->getAdvice();
+    foreach ($advice_documents as $advice) {
+      $advice->revoke();
+    }
+
+    $this->set('revocation_reason', $reason);
+    parent::revoke();
+  }
+
+  /**
    * Get the organisation contacts for this Partnership.
    */
   public function getOrganisationPeople() {

--- a/web/modules/features/par_rd_help_desk_flows/config/install/par_flows.par_flow.revoke_partnership.yml
+++ b/web/modules/features/par_rd_help_desk_flows/config/install/par_flows.par_flow.revoke_partnership.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies: {  }
+id: revoke_partnership
+label: 'Revoke Partnership'
+default_title: null
+default_section_title: null
+description: 'The revoke operations for a given partnership.'
+save_method: end
+steps:
+  1:
+    route: par_help_desks_flows.confirm_revoke_partnership
+    form_id: par_rd_help_desk_revoke_confirm
+    redirect:
+      next: 2
+      cancel: 3
+  2:
+    route: par_help_desks_flows.revoke_partnership
+    form_id: par_rd_help_desk_revoke
+    redirect:
+      done: 3
+  3:
+    route: view.helpdesk_dashboard.par_rd_helpdesk_dashboard_page

--- a/web/modules/features/par_rd_help_desk_flows/par_rd_help_desk_flows.routing.yml
+++ b/web/modules/features/par_rd_help_desk_flows/par_rd_help_desk_flows.routing.yml
@@ -24,6 +24,32 @@ par_help_desks_flows.approve_partnership:
     parameters:
       par_data_partnership:
         type: entity:par_data_partnership
+# PAR RD Help Desk journey - revoke partnership
+par_help_desks_flows.confirm_revoke_partnership:
+  path: '/helpdesk/partnership/{par_data_partnership}/revoke'
+  defaults:
+    _form: '\Drupal\par_rd_help_desk_flows\Form\ParRdHelpDeskRevokeConfirmForm'
+    _title_callback: '\Drupal\par_rd_help_desk_flows\Form\ParRdHelpDeskRevokeConfirmForm::titleCallback'
+  requirements:
+    _permission: 'approve partnerships via rd help desk'
+    _custom_access: '\Drupal\par_rd_help_desk_flows\Form\ParRdHelpDeskRevokeConfirmForm::accessCallback'
+    par_data_partnership: \d+
+  options:
+    parameters:
+      par_data_partnership:
+        type: entity:par_data_partnership
+par_help_desks_flows.revoke_partnership:
+  path: '/helpdesk/partnership/{par_data_partnership}/revoked'
+  defaults:
+    _form: '\Drupal\par_rd_help_desk_flows\Form\ParRdHelpDeskRevokeForm'
+    _title_callback: '\Drupal\par_rd_help_desk_flows\Form\ParRdHelpDeskRevokeForm::titleCallback'
+  requirements:
+    _permission: 'approve partnerships via rd help desk'
+    par_data_partnership: \d+
+  options:
+    parameters:
+      par_data_partnership:
+        type: entity:par_data_partnership
 # PAR RD Help Desk journey - invite users
 par_help_desks_flows.invite_members:
   path: '/helpdesk/partnership/{par_data_partnership}/invite/{par_data_person}'

--- a/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskRevokeConfirmForm.php
+++ b/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskRevokeConfirmForm.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Drupal\par_rd_help_desk_flows\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\par_flows\Form\ParBaseForm;
+use Drupal\par_data\Entity\ParDataPartnership;
+use Drupal\Core\Access\AccessResult;
+use Drupal\par_flows\ParDisplayTrait;
+
+/**
+ * The confirming the user is authorised to revoke partnerships.
+ */
+class ParRdHelpDeskRevokeConfirmForm extends ParBaseForm {
+
+  use ParDisplayTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $flow = 'revoke_partnership';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'par_rd_help_desk_revoke_confirm';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function titleCallback() {
+    return 'Confirmation | Revoke a partnership';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function accessCallback(ParDataPartnership $par_data_partnership = NULL) {
+    // 403 if the partnership is active/approved by RD.
+    if ($par_data_partnership->getRawStatus() !== 'confirmed_rd') {
+      $this->accessResult = AccessResult::forbidden('The partnership is not active.');
+    }
+
+    return parent::accessCallback();
+  }
+
+  /**
+   * Helper to get all the editable values when editing or
+   * revisiting a previously edited page.
+   */
+  public function retrieveEditableValues(ParDataPartnership $par_data_partnership = NULL) {
+
+    if ($par_data_partnership) {
+      // If we're editing an entity we should set the state
+      // to something other than default to avoid conflicts
+      // with existing versions of the same form.
+      $this->setState("edit:{$par_data_partnership->id()}");
+    }
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ParDataPartnership $par_data_partnership = NULL) {
+    $this->retrieveEditableValues($par_data_partnership);
+
+    // Present partnership info.
+    $form['partnership_info'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Revoke the partnership between'),
+      '#attributes' => ['class' => 'form-group'],
+    ];
+
+    $form['partnership_info']['partnership_text'] = [
+      '#type' => 'markup',
+      '#markup' => $par_data_partnership->label(),
+      '#prefix' => '<p>',
+      '#suffix' => '</p>',
+    ];
+
+    // Enter the revokcation reason.
+    $form['revocation_reason'] = [
+      '#title' => $this->t('Enter the reason you are revoking this partnership'),
+      '#type' => 'textarea',
+      '#rows' => 5,
+      '#default_value' => $this->getDefaultValues('revocation_reason', FALSE),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    // No validation yet.
+    parent::validateForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $par_data_partnership = $this->getRouteParam('par_data_partnership');
+
+    // We only want to update the status of active partnerships.
+    if (!$par_data_partnership->isRevoked()) {
+
+      $revoked = $par_data_partnership->revoke($this->getTempDataValue('revocation_reason'));
+
+      if ($revoked) {
+        $this->deleteStore();
+      }
+      else {
+        $message = $this->t('Revocation reason could not be saved for %form_id');
+        $replacements = [
+          '%form_id' => $this->getFormId(),
+        ];
+        $this->getLogger($this->getLoggerChannel())
+          ->error($message, $replacements);
+      }
+
+    }
+  }
+
+}

--- a/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskRevokeForm.php
+++ b/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskRevokeForm.php
@@ -7,27 +7,27 @@ use Drupal\par_data\Entity\ParDataPartnership;
 use Drupal\par_flows\Form\ParBaseForm;
 
 /**
- * Approving a new partnership.
+ * Revoking a partnership.
  */
-class ParRdHelpDeskApproveForm extends ParBaseForm {
+class ParRdHelpDeskRevokeForm extends ParBaseForm {
 
   /**
    * {@inheritdoc}
    */
-  protected $flow = 'approve_partnership';
+  protected $flow = 'revoke_partnership';
 
   /**
    * {@inheritdoc}
    */
   public function titleCallback() {
-    return "Confirmation | Partnership is approved";
+    return "RD Help Desk | Partnership revoked";
   }
 
   /**
    * {@inheritdoc}
    */
   public function getFormId() {
-    return 'par_rd_help_desk_approve';
+    return 'par_rd_help_desk_revoke';
   }
 
   /**
@@ -50,9 +50,9 @@ class ParRdHelpDeskApproveForm extends ParBaseForm {
   public function buildForm(array $form, FormStateInterface $form_state, ParDataPartnership $par_data_partnership = NULL) {
     $this->retrieveEditableValues($par_data_partnership);
 
-    $form['partnership_info'] = [
+    $form['partnership_info'] =[
       '#type' => 'fieldset',
-      '#title' => $this->t('The following partnership has been approved'),
+      '#title' => $this->t('The following partnership has been revoked'),
       '#attributes' => ['class' => 'form-group'],
       '#collapsible' => FALSE,
       '#collapsed' => FALSE,


### PR DESCRIPTION
This is the initial work to create the pages for the revocation journey (just the pages and the flow, no link to it yet so the journey can't really be used even if we merge this):

![screenshot from 2017-12-29 12-10-20](https://user-images.githubusercontent.com/334114/34436867-8aa71966-ec91-11e7-84ad-b1b243c9a78d.png)
![screenshot from 2017-12-29 12-10-03](https://user-images.githubusercontent.com/334114/34436868-8abe352e-ec91-11e7-823f-eed764d23cf5.png)

The titles and various texty bits on the pages are a bit of a mess really, there's very little consistency of wording between these two pages or even between the approve journey but we can address when everyone is in next week.
