### PR TITLE
PAR-1060 & PAR-1043: Partnerships that are in progress cannot be revoked.

### DIFF
--- a/web/modules/custom/par_data/src/Entity/ParDataEnforcementAction.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataEnforcementAction.php
@@ -68,7 +68,6 @@ class ParDataEnforcementAction extends ParDataEntity {
   const APPROVED = 'approved';
   const BLOCKED = 'blocked';
   const REFERRED = 'referred';
-  const AWAITING = 'awaiting_approval';
 
   /**
    * Get the blocked advice for this Enforcement Action.
@@ -156,7 +155,7 @@ class ParDataEnforcementAction extends ParDataEntity {
   public function isAwaitingApproval() {
     $status_field = $this->getTypeEntity()->getConfigurationElementByType('entity', 'status_field');
     $current_status = $status_field ? $this->get($status_field)->getString() : NULL;
-    return ($current_status === self::AWAITING);
+    return ($this->getTypeEntity()->getDefaultStatus() === $current_status);
   }
 
   /**
@@ -211,12 +210,24 @@ class ParDataEnforcementAction extends ParDataEntity {
   }
 
   /**
- *  Get the referred note data from the current action.
- *
- * @return String referred_text | NULL
- *   The referred text stored on the current action or null.
- *
- */
+   * {@inheritdoc}
+   */
+  public function inProgress() {
+    // Freeze Enforcement Actions that are awaiting approval.
+    if ($this->getTypeEntity()->getDefaultStatus() === $this->getRawStatus()) {
+      return TRUE;
+    }
+
+    return parent::inProgress();
+  }
+
+  /**
+   *  Get the referred note data from the current action.
+   *
+   * @return String referred_text | NULL
+   *   The referred text stored on the current action or null.
+   *
+   */
   public function getReferralNotes() {
     return $this->get('referral_notes')->getString();
   }

--- a/web/modules/custom/par_data/src/Entity/ParDataEnforcementAction.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataEnforcementAction.php
@@ -190,7 +190,7 @@ class ParDataEnforcementAction extends ParDataEntity {
   }
 
   /**
-   *  Refer an Action of an Enforcement notification.
+   * Refer an Action of an Enforcement notification.
    *
    * @param string $authority_notes
    *  referral notes indicating the reason for the referral status update in the form.
@@ -222,7 +222,7 @@ class ParDataEnforcementAction extends ParDataEntity {
   }
 
   /**
-   *  Get the referred note data from the current action.
+   * Get the referred note data from the current action.
    *
    * @return String referred_text | NULL
    *   The referred text stored on the current action or null.
@@ -233,7 +233,7 @@ class ParDataEnforcementAction extends ParDataEntity {
   }
 
   /**
-   *  Get the primary authority notes data from the current action.
+   * Get the primary authority notes data from the current action.
    *
    * @return String primary_authority_notes | NULL
    *   The referred text stored on the current action or null.

--- a/web/modules/custom/par_data/src/Entity/ParDataEnforcementNotice.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataEnforcementNotice.php
@@ -65,9 +65,26 @@ use Drupal\Core\Field\BaseFieldDefinition;
 class ParDataEnforcementNotice extends ParDataEntity {
 
   /**
+   * {@inheritdoc}
+   */
+  public function inProgress() {
+    // Freeze Enforcement Notices with actions that are awaiting approval.
+    foreach ($this->getEnforcementActions() as $action) {
+      if ($action->inProgress()) {
+        return TRUE;
+      }
+    }
+
+    return parent::inProgress();
+  }
+
+  /**
    * Get the primary authority for this Enforcement Notice.
    *
    * @param boolean $single
+   *
+   * @return ParDataEntityInterface|bool
+   *   Return false if not referred.
    *
    */
   public function getPrimaryAuthority($single = FALSE) {

--- a/web/modules/custom/par_data/src/Entity/ParDataEntityInterface.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataEntityInterface.php
@@ -41,6 +41,14 @@ interface ParDataEntityInterface {
   public function setParStatus($value);
 
   /**
+   * Any entity that is in progress can't be revoked, archived or deleted.
+   *
+   * @return bool
+   *   TRUE if entity is in progress.
+   */
+  public function inProgress();
+
+  /**
    * Get the level of completion of this entity.
    *
    * @return NULL|integer

--- a/web/modules/custom/par_data/src/Entity/ParDataPartnership.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataPartnership.php
@@ -89,6 +89,26 @@ class ParDataPartnership extends ParDataEntity {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function inProgress() {
+    // Freeze partnerships that are awaiting approval.
+    if ($this->getTypeEntity()->getDefaultStatus() === $this->getRawStatus()) {
+      return TRUE;
+    }
+
+    // Freeze partnerships that have un un approved enforcement notices
+    $enforcement_notices = $this->getRelationships('par_data_enforcement_notice');
+    foreach ($enforcement_notices as $enforcement_notice) {
+      if ($enforcement_notice->inProgress()) {
+        return TRUE;
+      }
+    }
+
+    return parent::inProgress();
+  }
+
+  /**
    * Get the organisation contacts for this Partnership.
    */
   public function getOrganisationPeople() {

--- a/web/modules/features/par_enforcement_flows/src/Controller/ParEnforcementFlowsCompletedEnforcementController.php
+++ b/web/modules/features/par_enforcement_flows/src/Controller/ParEnforcementFlowsCompletedEnforcementController.php
@@ -22,19 +22,11 @@ class ParEnforcementFlowsCompletedEnforcementController extends ParBaseControlle
    */
   public function accessCallback(ParDataEnforcementNotice $par_data_enforcement_notice = NULL) {
 
-    $allowed_actions = [
-      ParDataEnforcementAction::APPROVED,
-      ParDataEnforcementAction::BLOCKED,
-      ParDataEnforcementAction::REFERRED,
-      ParDataEnforcementAction::AWAITING,
-    ];
-
-    foreach ($par_data_enforcement_notice->get('field_enforcement_action')->referencedEntities() as $delta => $action) {
-      // If this enforcement notice has any actions that have not yet been reviewed deny access.
-      if (in_array($action->getRawStatus(), $allowed_actions) && $action->getRawStatus() === ParDataEnforcementAction::AWAITING) {
-        $this->accessResult = AccessResult::forbidden('This enforcement notification has not been fully reviewed yet.');
-      }
+    // If this enforcement notice has not been reviewed.
+    if ($par_data_enforcement_notice->inProgress()) {
+      $this->accessResult = AccessResult::forbidden('This enforcement notification has not been fully reviewed yet.');
     }
+
     return parent::accessCallback();
   }
 

--- a/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskRevokeConfirmForm.php
+++ b/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskRevokeConfirmForm.php
@@ -38,8 +38,8 @@ class ParRdHelpDeskRevokeConfirmForm extends ParBaseForm {
    * {@inheritdoc}
    */
   public function accessCallback(ParDataPartnership $par_data_partnership = NULL) {
-    // 403 if the partnership is active/approved by RD.
-    if ($par_data_partnership->getRawStatus() !== 'confirmed_rd') {
+    // 403 if the partnership is in progress it can't be revoked.
+    if ($par_data_partnership->inProgress()) {
       $this->accessResult = AccessResult::forbidden('The partnership is not active.');
     }
 
@@ -67,7 +67,16 @@ class ParRdHelpDeskRevokeConfirmForm extends ParBaseForm {
   public function buildForm(array $form, FormStateInterface $form_state, ParDataPartnership $par_data_partnership = NULL) {
     $this->retrieveEditableValues($par_data_partnership);
 
-    // Present partnership info.
+    if ($par_data_partnership && $par_data_partnership->inProgress()) {
+      $form['partnership_info'] = [
+        '#type' => 'markup',
+        '#title' => $this->t('Revocation denied'),
+        '#markup' => $this->t('This partnership cannot be revoked because it is awaiting approval or there are enforcement notices currently awaiting review. Please try again later.'),
+      ];
+
+      return parent::buildForm($form, $form_state);
+    }
+
     $form['partnership_info'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Revoke the partnership between'),


### PR DESCRIPTION
Added an `inProgress` method for determining when an entity may be revoked, archived or deleted.

However, because we're using access control to deny access to the page if the operation cannot be performed then the actual message in the UI (PAR-1060) never really gets displayed, what happens instead is that the link is never offered on the dashboard. This has been the practice for the approval journey and various other journeys so I think best to stick with this, but it does change the A/C a little.