### PR TITLE
PAR-1057 RD dashboard: Add 'Revoked' to partnership search filter and link to revoke partnership.

### DIFF
--- a/sync/views.view.helpdesk_dashboard.yml
+++ b/sync/views.view.helpdesk_dashboard.yml
@@ -1139,7 +1139,7 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: N/A
+          empty: ''
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true

--- a/sync/views.view.helpdesk_dashboard.yml
+++ b/sync/views.view.helpdesk_dashboard.yml
@@ -107,6 +107,7 @@ display:
             partnership_type: partnership_type
             partnership_status: partnership_status
             par_flow_link: par_flow_link
+            par_flow_link_1: par_flow_link
           info:
             id:
               sortable: false
@@ -144,6 +145,13 @@ display:
               empty_column: false
               responsive: ''
             par_flow_link:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            par_flow_link_1:
               sortable: false
               default_sort_order: asc
               align: ''
@@ -645,6 +653,10 @@ display:
                 title: Active
                 operator: '='
                 value: confirmed_rd
+              5:
+                title: Revoked
+                operator: '='
+                value: revoked
           entity_type: par_data_partnership
           entity_field: partnership_status
           plugin_id: string
@@ -1149,6 +1161,59 @@ display:
           link: '/helpdesk/partnership/{{ id }}/confirm'
           hidden: 1
           entity_type: par_data_authority
+          plugin_id: par_flow_link
+        par_flow_link_1:
+          id: par_flow_link_1
+          table: par_partnerships_field_data
+          field: par_flow_link
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Action
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          title: 'Revoke Partnership'
+          link: '/helpdesk/partnership/{{ id }}/revoke'
+          hidden: 1
+          entity_type: par_data_partnership
           plugin_id: par_flow_link
     cache_metadata:
       max-age: 0

--- a/sync/views.view.helpdesk_dashboard.yml
+++ b/sync/views.view.helpdesk_dashboard.yml
@@ -1045,10 +1045,10 @@ display:
           entity_type: par_data_partnership
           entity_field: partnership_type
           plugin_id: field
-        partnership_status:
-          id: partnership_status
-          table: par_partnerships_field_revision
-          field: partnership_status
+        par_status:
+          id: par_status
+          table: par_partnerships_field_data
+          field: par_status
           relationship: none
           group_type: group
           admin_label: ''
@@ -1093,22 +1093,8 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: par_list_formatter
-          settings: {  }
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
           entity_type: par_data_partnership
-          entity_field: partnership_status
-          plugin_id: field
+          plugin_id: par_data_status
         par_flow_link:
           id: par_flow_link
           table: par_authorities_field_data

--- a/web/modules/custom/par_data/src/Entity/ParDataEntity.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataEntity.php
@@ -21,7 +21,7 @@ class ParDataEntity extends Trance implements ParDataEntityInterface {
 
   const DELETE_FIELD = 'deleted';
   const REVOKE_FIELD = 'revoked';
-  const ARCHIVE_FIELD = 'archive';
+  const ARCHIVE_FIELD = 'archived';
 
   /**
    * Simple getter to inject the PAR Data Manager service.

--- a/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskApproveConfirmForm.php
+++ b/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskApproveConfirmForm.php
@@ -36,6 +36,7 @@ class ParRdHelpDeskApproveConfirmForm extends ParBaseForm {
    */
   public function accessCallback(ParDataPartnership $par_data_partnership = NULL) {
     // If partnership has been revoked, we should not be able to approve it.
+    // @todo This needs to be re-addressed as per PAR-1082.
     if ($par_data_partnership->isRevoked()) {
       $this->accessResult = AccessResult::forbidden('The partnership has been revoked.');
     }

--- a/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskApproveConfirmForm.php
+++ b/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskApproveConfirmForm.php
@@ -35,6 +35,11 @@ class ParRdHelpDeskApproveConfirmForm extends ParBaseForm {
    * {@inheritdoc}
    */
   public function accessCallback(ParDataPartnership $par_data_partnership = NULL) {
+    // If partnership has been revoked, we should not be able to approve it.
+    if ($par_data_partnership->isRevoked()) {
+      $this->accessResult = AccessResult::forbidden('The partnership has been revoked.');
+    }
+
     // 403 if the partnership is active/approved by RD.
     if ($par_data_partnership->getRawStatus() === 'confirmed_rd') {
       $this->accessResult = AccessResult::forbidden('The partnership is active.');

--- a/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskRevokeConfirmForm.php
+++ b/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskRevokeConfirmForm.php
@@ -38,6 +38,11 @@ class ParRdHelpDeskRevokeConfirmForm extends ParBaseForm {
    * {@inheritdoc}
    */
   public function accessCallback(ParDataPartnership $par_data_partnership = NULL) {
+    // If partnership has been revoked, we should not be able to re-revoke it.
+    if ($par_data_partnership->isRevoked()) {
+      $this->accessResult = AccessResult::forbidden('The partnership is already revoked.');
+    }
+
     // 403 if the partnership is in progress it can't be revoked.
     if ($par_data_partnership->inProgress()) {
       $this->accessResult = AccessResult::forbidden('The partnership is not active.');


### PR DESCRIPTION
<img width="993" alt="cursor_and_rd_help_desk___dashboard___primary_authority_register" src="https://user-images.githubusercontent.com/150512/34574970-f20e5586-f170-11e7-9721-371e24bbfbb2.png">

See screenshot for the revoked search filter option and the revoke partnership link.
  