### PR TITLE
PAR-1078: Enable revisioning for PAR entities with a `status_field`

### DIFF
--- a/web/modules/custom/par_data/src/Entity/ParDataEntity.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataEntity.php
@@ -40,6 +40,18 @@ class ParDataEntity extends Trance implements ParDataEntityInterface {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  public function save() {
+    // Create a revision when a PAR entity is saved.
+    $this->setNewRevision(TRUE);
+    $this->setRevisionCreationTime(REQUEST_TIME);
+    $this->setRevisionAuthorId(\Drupal::currentUser()->id());
+
+    return parent::save();
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function getViewBuilder() {


### PR DESCRIPTION
Similarly named PR in this may have code that supersedes this, but it did not seem to work, so original solution is still on the cards until we have a fix for this.

_this is crucial for finding when a partnership was revoked_