### PR TITLE
PAR-1084 - Allow filtering partnerships by revoked status

### DIFF
--- a/sync/views.view.helpdesk_dashboard.yml
+++ b/sync/views.view.helpdesk_dashboard.yml
@@ -596,70 +596,6 @@ display:
             authority_name: authority_name
             organisation_name: organisation_name
           plugin_id: combine
-        partnership_status:
-          id: partnership_status
-          table: par_partnerships_field_revision
-          field: partnership_status
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '!='
-          value: yo
-          group: 1
-          exposed: true
-          expose:
-            operator_id: partnership_status_op
-            label: 'Partnership Status'
-            description: ''
-            use_operator: false
-            operator: partnership_status_op
-            identifier: partnership_status
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              par_authority: '0'
-              par_business: '0'
-              par_coordinator: '0'
-              par_helpdesk: '0'
-          is_grouped: true
-          group_info:
-            label: Status
-            description: 'Filter by partnership status'
-            identifier: partnership_status
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: '4'
-            default_group_multiple: {  }
-            group_items:
-              1:
-                title: 'Awaiting Review'
-                operator: '='
-                value: awaiting_review
-              2:
-                title: 'Confirmed by the Authority'
-                operator: '='
-                value: confirmed_authority
-              3:
-                title: 'Confirmed by the Business'
-                operator: '='
-                value: confirmed_business
-              4:
-                title: Active
-                operator: '='
-                value: confirmed_rd
-              5:
-                title: Revoked
-                operator: '='
-                value: revoked
-          entity_type: par_data_partnership
-          entity_field: partnership_status
-          plugin_id: string
         status:
           id: status
           table: par_partnerships_field_data
@@ -697,6 +633,94 @@ display:
             group_items: {  }
           entity_type: par_data_partnership
           entity_field: status
+          plugin_id: boolean
+        partnership_status_1:
+          id: partnership_status_1
+          table: par_partnerships_field_data
+          field: partnership_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: awaiting_review
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Partnership Status'
+            description: ''
+            use_operator: false
+            operator: partnership_status_1_op
+            identifier: partnership_status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              par_authority: '0'
+              par_enforcement: '0'
+              par_organisation: '0'
+              par_helpdesk: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: par_data_partnership
+          entity_field: partnership_status
+          plugin_id: par_data_status_filter
+        revoked:
+          id: revoked
+          table: par_partnerships_field_data
+          field: revoked
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Revoked
+            description: ''
+            use_operator: false
+            operator: revoked_op
+            identifier: revoked
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              par_authority: '0'
+              par_enforcement: '0'
+              par_organisation: '0'
+              par_helpdesk: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: par_data_partnership
+          entity_field: revoked
           plugin_id: boolean
       sorts: {  }
       title: 'RD Help Desk | Dashboard'


### PR DESCRIPTION

<img width="965" alt="rd_help_desk___dashboard___primary_authority_register_and_2__stemount_winning____projects_par-beta__zsh_" src="https://user-images.githubusercontent.com/150512/34789205-45c576fa-f635-11e7-98b2-eaab25b055c6.png">

Updating to the PAR Status Filter as per uniform with other views.