### PR TITLE
PAR-1044

### DIFF
--- a/web/modules/custom/par_data/src/Entity/ParDataEnforcementAction.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataEnforcementAction.php
@@ -120,7 +120,7 @@ class ParDataEnforcementAction extends ParDataEntity {
   }
 
   /**
-   * Check if this entity is revoked.
+   * Check if this entity is blocked.
    *
    * @return bool
    */

--- a/web/modules/custom/par_data/src/ParDataManager.php
+++ b/web/modules/custom/par_data/src/ParDataManager.php
@@ -586,7 +586,7 @@ class ParDataManager implements ParDataManagerInterface {
     $account = \Drupal::currentUser();
 
     // Remove revoked partnerships from internal system queries.
-    if ($display_revoked_partnerships === FALSE && $type == 'par_data_partnership' && !$account->hasPermission('VIEW_REVOKED_PARTNERSHIPS') {
+  if ($display_revoked_partnerships === FALSE && $type == 'par_data_partnership') {
 
       $conditions[] = [
           'revoked' => [
@@ -596,6 +596,7 @@ class ParDataManager implements ParDataManagerInterface {
             ]
           ],
       ];
+
     }
 
     foreach ($conditions as $row) {

--- a/web/modules/custom/par_data/src/ParDataManager.php
+++ b/web/modules/custom/par_data/src/ParDataManager.php
@@ -13,11 +13,11 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\file\FileInterface;
 use Drupal\par_data\Entity\ParDataAuthority;
+use Drupal\par_data\Entity\ParDataEntityInterface;
 use Drupal\par_data\Entity\ParDataEntity;
 use Drupal\par_data\Entity\ParDataPerson;
 use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
-use Drupal\Core\Access\AccessResult;
 
 /**
 * Manages all functionality universal to Par Data.

--- a/web/modules/custom/par_data/src/ParDataManager.php
+++ b/web/modules/custom/par_data/src/ParDataManager.php
@@ -13,10 +13,11 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\file\FileInterface;
 use Drupal\par_data\Entity\ParDataAuthority;
-use Drupal\par_data\Entity\ParDataEntityInterface;
+use Drupal\par_data\Entity\ParDataEntity;
 use Drupal\par_data\Entity\ParDataPerson;
 use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
+use Drupal\Core\Access\AccessResult;
 
 /**
 * Manages all functionality universal to Par Data.
@@ -538,10 +539,15 @@ class ParDataManager implements ParDataManagerInterface {
    *
    * @param string $type
    *   An entity type to query.
+   *
    * @param array $conditions
    *   Query conditions.
+   *
    * @param integer $limit
    *   Limit number of results.
+   *
+   * @param integer $display_revoked_partnerships
+   *   Weather or not to override system checks for removing revoked partnerships from queries.
    *
    * @code
    * $conditions = [
@@ -574,8 +580,23 @@ class ParDataManager implements ParDataManagerInterface {
    * @see \Drupal\Core\Entity\Query\andConditionGroup
    * @see \Drupal\Core\Entity\Query\orConditionGroup
    */
-  public function getEntitiesByQuery(string $type, array $conditions, $limit = NULL) {
+  public function getEntitiesByQuery(string $type, array $conditions, $limit = NULL, $display_revoked_partnerships = FALSE) {
     $entities = [];
+
+    $account = \Drupal::currentUser();
+
+    // Remove revoked partnerships from internal system queries.
+    if ($display_revoked_partnerships === FALSE && $type == 'par_data_partnership' && !$account->hasPermission('VIEW_REVOKED_PARTNERSHIPS') {
+
+      $conditions[] = [
+          'revoked' => [
+            'AND' => [
+              [ParDataEntity::REVOKE_FIELD, 0],
+              [ParDataEntity::DELETE_FIELD, 0],
+            ]
+          ],
+      ];
+    }
 
     foreach ($conditions as $row) {
       $query = \Drupal::entityQuery($type);


### PR DESCRIPTION
This ticket refers to a spike to investigate the ways in which we can implement the custom business logic rules required around revoked entities.

There instances of internal system queries that currently will return revoked partnership entities.

![screen shot 2018-01-11 at 14 47 24](https://user-images.githubusercontent.com/772018/34831268-65265c7c-f6de-11e7-900b-6b2d472aa80a.png)

The internal system entities queries utilise the function getEntitiesByQuery() for retrieving par_data entities to be used for custom logic within the system.

The code in this branch extends the getEntitiesByQuery() providing a way to remove deleted and revoked entities from being retrieved and used internally, preventing various system failures.

There is an optional override parameter which will return revoked entities when required by bypassing this logic if needed.

There is also a need to address views that currently list partnership entities and possibly a need to extend the storage class for par_data entities for future requirements.   
 
