### PR TITLE
PAR-1134: Added new gds date form element

### DIFF
--- a/sync/core.entity_view_display.par_data_coordinated_business.coordinated_business.default.yml
+++ b/sync/core.entity_view_display.par_data_coordinated_business.coordinated_business.default.yml
@@ -30,8 +30,8 @@ content:
     region: content
     label: above
     settings:
-      format_type: medium
       timezone_override: ''
+      format_type: gds_date_format
     third_party_settings: {  }
   date_membership_ceased:
     type: datetime_default
@@ -39,8 +39,8 @@ content:
     region: content
     label: above
     settings:
-      format_type: medium
       timezone_override: ''
+      format_type: gds_date_format
     third_party_settings: {  }
   field_legal_entity:
     type: entity_reference_entity_view
@@ -48,8 +48,8 @@ content:
     region: content
     label: hidden
     settings:
-      link: true
-      view_mode: default
+      view_mode: summary
+      link: false
     third_party_settings: {  }
   field_organisation:
     weight: 1

--- a/sync/core.entity_view_display.par_data_coordinated_business.coordinated_business.default.yml
+++ b/sync/core.entity_view_display.par_data_coordinated_business.coordinated_business.default.yml
@@ -21,14 +21,14 @@ content:
     type: par_boolean_formatter
     weight: 3
     region: content
-    label: above
+    label: inline
     settings: {  }
     third_party_settings: {  }
   date_membership_began:
     type: datetime_default
     weight: 4
     region: content
-    label: above
+    label: hidden
     settings:
       timezone_override: ''
       format_type: gds_date_format
@@ -37,7 +37,7 @@ content:
     type: datetime_default
     weight: 5
     region: content
-    label: above
+    label: hidden
     settings:
       timezone_override: ''
       format_type: gds_date_format

--- a/sync/core.entity_view_display.par_data_coordinated_business.coordinated_business.full.yml
+++ b/sync/core.entity_view_display.par_data_coordinated_business.coordinated_business.full.yml
@@ -1,0 +1,66 @@
+uuid: 82444ace-74a1-4614-aba8-181030ab0281
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.par_data_coordinated_business.full
+    - field.field.par_data_coordinated_business.coordinated_business.field_legal_entity
+    - field.field.par_data_coordinated_business.coordinated_business.field_organisation
+    - par_data.par_data_coordinated_business_type.coordinated_business
+  module:
+    - datetime
+    - par_data
+_core:
+  default_config_hash: wrQCLd0nUJy7r_OzKr59VHEfrL0-OPBdzhlsEI65aYs
+id: par_data_coordinated_business.coordinated_business.full
+targetEntityType: par_data_coordinated_business
+bundle: coordinated_business
+mode: full
+content:
+  covered_by_inspection:
+    type: par_boolean_formatter
+    weight: 2
+    region: content
+    label: inline
+    settings: {  }
+    third_party_settings: {  }
+  date_membership_began:
+    type: datetime_default
+    weight: 3
+    region: content
+    label: inline
+    settings:
+      timezone_override: ''
+      format_type: gds_date_format
+    third_party_settings: {  }
+  date_membership_ceased:
+    type: datetime_default
+    weight: 4
+    region: content
+    label: inline
+    settings:
+      timezone_override: ''
+      format_type: gds_date_format
+    third_party_settings: {  }
+  field_legal_entity:
+    type: entity_reference_entity_view
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      view_mode: summary
+      link: false
+    third_party_settings: {  }
+  field_organisation:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: title
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  membership_date: true
+  name: true
+  user_id: true

--- a/sync/core.entity_view_display.par_data_coordinated_business.coordinated_business.summary.yml
+++ b/sync/core.entity_view_display.par_data_coordinated_business.coordinated_business.summary.yml
@@ -1,0 +1,43 @@
+uuid: 27878135-e973-4ff5-8250-d6347067133f
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.par_data_coordinated_business.summary
+    - field.field.par_data_coordinated_business.coordinated_business.field_legal_entity
+    - field.field.par_data_coordinated_business.coordinated_business.field_organisation
+    - par_data.par_data_coordinated_business_type.coordinated_business
+  module:
+    - datetime
+_core:
+  default_config_hash: wrQCLd0nUJy7r_OzKr59VHEfrL0-OPBdzhlsEI65aYs
+id: par_data_coordinated_business.coordinated_business.summary
+targetEntityType: par_data_coordinated_business
+bundle: coordinated_business
+mode: summary
+content:
+  date_membership_began:
+    type: datetime_default
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      timezone_override: ''
+      format_type: gds_date_format
+    third_party_settings: {  }
+  field_organisation:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: title
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  covered_by_inspection: true
+  date_membership_ceased: true
+  field_legal_entity: true
+  membership_date: true
+  name: true
+  user_id: true

--- a/sync/core.entity_view_display.par_data_coordinated_business.coordinated_business.title.yml
+++ b/sync/core.entity_view_display.par_data_coordinated_business.coordinated_business.title.yml
@@ -1,0 +1,33 @@
+uuid: 99a054c5-d78c-4304-bbe3-a074a5b363da
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.par_data_coordinated_business.title
+    - field.field.par_data_coordinated_business.coordinated_business.field_legal_entity
+    - field.field.par_data_coordinated_business.coordinated_business.field_organisation
+    - par_data.par_data_coordinated_business_type.coordinated_business
+_core:
+  default_config_hash: wrQCLd0nUJy7r_OzKr59VHEfrL0-OPBdzhlsEI65aYs
+id: par_data_coordinated_business.coordinated_business.title
+targetEntityType: par_data_coordinated_business
+bundle: coordinated_business
+mode: title
+content:
+  field_organisation:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: title
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  covered_by_inspection: true
+  date_membership_began: true
+  date_membership_ceased: true
+  field_legal_entity: true
+  membership_date: true
+  name: true
+  user_id: true

--- a/sync/core.entity_view_mode.par_data_coordinated_business.full.yml
+++ b/sync/core.entity_view_mode.par_data_coordinated_business.full.yml
@@ -1,0 +1,12 @@
+uuid: 163efdf7-3760-449d-93c8-56851025d547
+langcode: en
+status: true
+dependencies:
+  module:
+    - par_data
+_core:
+  default_config_hash: gO7pF57YSB9xCcHzgYWZi0niGxeBrpHRAGX-ICVL9uY
+id: par_data_coordinated_business.full
+label: Full
+targetEntityType: par_data_coordinated_business
+cache: true

--- a/sync/core.entity_view_mode.par_data_coordinated_business.summary.yml
+++ b/sync/core.entity_view_mode.par_data_coordinated_business.summary.yml
@@ -1,0 +1,12 @@
+uuid: e404a30e-4cbe-4190-a4a0-aadf83aa8d37
+langcode: en
+status: true
+dependencies:
+  module:
+    - par_data
+_core:
+  default_config_hash: 5ICJ1XHiKZKdUnZQlXeQ04LPyX7YT1gGSF1WKmtE870
+id: par_data_coordinated_business.summary
+label: Summary
+targetEntityType: par_data_coordinated_business
+cache: true

--- a/sync/core.entity_view_mode.par_data_coordinated_business.title.yml
+++ b/sync/core.entity_view_mode.par_data_coordinated_business.title.yml
@@ -1,0 +1,12 @@
+uuid: 9f81edd8-a315-46cf-b9b3-c55496b87e0a
+langcode: en
+status: true
+dependencies:
+  module:
+    - par_data
+_core:
+  default_config_hash: snt2ckla7pp5ysIdHJH1K4JLZCHfSV65mR576FMHV7o
+id: par_data_coordinated_business.title
+label: Title
+targetEntityType: par_data_coordinated_business
+cache: true

--- a/sync/par_flows.par_flow.member_add.yml
+++ b/sync/par_flows.par_flow.member_add.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 _core:
-  default_config_hash: Mieip540v5IyWL1OhvfbI-GX36rrr1Jwfbtt7YV6SSQ
+  default_config_hash: xnDekATlye0-oxaNsgEGGXbq0N9KKKQfOzbYsO_JpYA
 id: member_add
 label: 'Member Add Flow'
 default_title: null
@@ -73,7 +73,7 @@ steps:
       legal_select: par_member_add_legal_entity
       covered_by: par_member_add_inspection_plan_coverage
     redirect:
-      save: 10
+      save: 9
       cancel: 10
   9:
     route: par_member_add_flows.member_confirmation

--- a/web/modules/custom/par_forms/par_forms.module
+++ b/web/modules/custom/par_forms/par_forms.module
@@ -22,3 +22,14 @@ function par_forms_help($route_name, RouteMatchInterface $route_match) {
     default:
   }
 }
+
+function par_forms_theme($existing, $type, $theme, $path) {
+  $variables = [
+    'gds_date' => [
+      'render element' => 'element',
+      'template' => 'gds-date',
+    ],
+  ];
+
+  return $variables;
+}

--- a/web/modules/custom/par_forms/src/Element/GdsDate.php
+++ b/web/modules/custom/par_forms/src/Element/GdsDate.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\par_forms\Element;
+
+use Drupal\Core\Render\Element\RenderElement;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+
+/**
+ * Provides a GDS Date element.
+ *
+ * @FormElement("gds_date")
+ */
+class GdsDate extends RenderElement {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getInfo() {
+    $class = get_class($this);
+
+    return [
+      '#input' => TRUE,
+      '#theme' => 'gds_date',
+      '#label' => 'Enter the date',
+      '#description' => 'The GDS supported date input.',
+      '#process' => [[$class, 'processGdsDate']],
+      '#pre_render' => [[$class, 'preRenderGdsDate']],
+      '#theme_wrappers' => ['form_element'],
+    ];
+  }
+
+  /**
+   * Prepare the render array for the template.
+   */
+  public static function preRenderGdsDate($element) {
+    // First name
+    $element['day'] = [
+      '#type' => 'textfield',
+      '#label' => 'Day',
+      '#attributes' => [
+        'name' => $element['#name'] ."_day",
+        'pattern' => "[0-9]*",
+        'size' => 6,
+        'class' => ['gds-date-sub-element']
+      ],
+      '#required' => $element['#required'],
+    ];
+
+    // Last name
+    $element['month'] = [
+      '#type' => 'textfield',
+      '#label' => 'Month',
+      '#attributes' => [
+        'name' => $element['#name'] ."_month",
+        'pattern' => "[0-9]*",
+        'size' => 6,
+        'class' => ['gds-date-sub-element']
+      ],
+      '#required' => $element['#required'],
+    ];
+
+    $element['year'] = [
+      '#type' => 'textfield',
+      '#label' => 'Year',
+      '#attributes' => [
+        'name' => $element['#name'] ."_year",
+        'pattern' => "[0-9]*",
+        'size' => 12,
+        'class' => ['gds-date-sub-element']
+      ],
+      '#required' => $element['#required'],
+    ];
+
+    // Default value.
+    $element['#default_value'] = ['day', 'month', 'year'];
+
+    return $element;
+  }
+
+  /**
+   * Copy the user inputs to the parent field value.
+   */
+  public static function processGdsDate(&$element, FormStateInterface $form_state, &$complete_form) {
+    // Get all form inputs
+    $inputs = $form_state->getUserInput();
+
+    // Get the parent field name
+    $name = $element['#name'];
+
+    // Prep the value.
+    if (isset($inputs["{$name}_day"]) && isset($inputs["{$name}_month"]) && isset($inputs["{$name}_year"])) {
+      $element['#value'] = ['day' => $inputs["{$name}_day"], 'month' => $inputs["{$name}_month"], 'year' => $inputs["{$name}_year"]];
+      $form_state->setValue($name, $element['#value']);
+    }
+
+    return $element;
+  }
+}

--- a/web/modules/custom/par_forms/src/Element/GdsDate.php
+++ b/web/modules/custom/par_forms/src/Element/GdsDate.php
@@ -2,12 +2,25 @@
 
 namespace Drupal\par_forms\Element;
 
+use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Render\Element\CompositeFormElementTrait;
 use Drupal\Core\Render\Element\FormElement;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Provides a GDS Date element.
+ *
+ * Properties:
+ * - #default_value: An array with the keys: 'year', 'month', and 'day'.
+ *   Defaults to the current date if no value is supplied.
+ *
+ * @code
+ * $form['expiration'] = array(
+ *   '#type' => 'date',
+ *   '#title' => $this->t('Content expiration'),
+ *   '#default_value' => ['year' => 2020, 'month' => 2, 'day' => 15,]
+ * );
+ * @endcode
  *
  * @FormElement("gds_date")
  */
@@ -24,18 +37,23 @@ class GdsDate extends FormElement {
     return [
       '#input' => TRUE,
       '#theme' => 'gds_date',
-      '#process' => [[$class, 'processGdsDate']],
+      '#process' => [
+        [$class, 'processGdsDate']
+      ],
       '#pre_render' => [
         [$class, 'preRenderCompositeFormElement'],
-        [$class, 'preRenderGdsDate'],
       ],
+      '#date_date_format' => 'Y-m-d',
+      '#theme_wrappers' => ['form_element'],
     ];
   }
 
   /**
-   * Prepare the render array for the template.
+   * Copy the user inputs to the parent field value.
    */
-  public static function preRenderGdsDate($element) {
+  public static function processGdsDate(&$element, FormStateInterface $form_state, &$complete_form) {
+    $value = is_array($element['#value']) ? $element['#value'] : [];
+
     $element['day'] = [
       '#type' => 'textfield',
       '#title' => 'Day',
@@ -46,6 +64,7 @@ class GdsDate extends FormElement {
         'class' => ['gds-date-sub-element']
       ],
       '#required' => $element['#required'],
+      '#default_value' => isset($value['day']) ? $value['day'] : $element['#default_value']['day'],
     ];
 
     $element['month'] = [
@@ -58,6 +77,7 @@ class GdsDate extends FormElement {
         'class' => ['gds-date-sub-element']
       ],
       '#required' => $element['#required'],
+      '#default_value' => isset($value['month']) ? $value['month'] : $element['#default_value']['month'],
     ];
 
     $element['year'] = [
@@ -70,30 +90,52 @@ class GdsDate extends FormElement {
         'class' => ['gds-date-sub-element']
       ],
       '#required' => $element['#required'],
+      '#default_value' => isset($value['year']) ? $value['year'] : $element['#default_value']['year'],
     ];
 
-    // Default value.
-    $element['#default_value'] = ['day', 'month', 'year'];
+    // Prep the value.
+    $inputs = $form_state->getUserInput();
+    $name = $element['#name'];
+    if (isset($inputs["{$name}_day"]) && isset($inputs["{$name}_month"]) && isset($inputs["{$name}_year"])) {
+      $date_input = implode('-', [$inputs["{$name}_year"], $inputs["{$name}_month"], $inputs["{$name}_day"]]);
+      $date_format = !empty($element['#date_date_format']) ? $element['#date_date_format'] : 'Y-m-d';
+      $element['#value'] = '';
+
+      try {
+        $date = DrupalDateTime::createFromFormat($date_format, $date_input, NULL, ['validate_format' => FALSE]);
+        $element['#value'] = $date->format($date_format);
+      }
+      catch (\Exception $e) {
+        $date = NULL;
+      }
+
+      $form_state->setValue($name, $element['#value']);
+    }
 
     return $element;
   }
 
   /**
-   * Copy the user inputs to the parent field value.
+   * {@inheritdoc}
    */
-  public static function processGdsDate(&$element, FormStateInterface $form_state, &$complete_form) {
-    // Get all form inputs
-    $inputs = $form_state->getUserInput();
+  public static function valueCallback(&$element, $input, FormStateInterface $form_state) {
+    $date_format = !empty($element['#date_date_format']) ? $element['#date_date_format'] : 'Y-m-d';
 
-    // Get the parent field name
-    $name = $element['#name'];
-
-    // Prep the value.
-    if (isset($inputs["{$name}_day"]) && isset($inputs["{$name}_month"]) && isset($inputs["{$name}_year"])) {
-      $element['#value'] = ['day' => $inputs["{$name}_day"], 'month' => $inputs["{$name}_month"], 'year' => $inputs["{$name}_year"]];
-      $form_state->setValue($name, $element['#value']);
+    if (is_string($element['#default_value'])) {
+      try {
+        $date = DrupalDateTime::createFromFormat($date_format, $element['#default_value'], NULL, ['validate_format' => FALSE]);
+        $value = [
+          'day' => $date->format('d'),
+          'month' => $date->format('m'),
+          'year' => $date->format('Y'),
+        ];
+      } catch (\Exception $e) {
+        $value = [];
+      }
+      return $value;
     }
-
-    return $element;
+    else {
+      return [];
+    }
   }
 }

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParBeginDateForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParBeginDateForm.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\par_forms\Plugin\ParForm;
+
+use Drupal\par_forms\ParFormPluginBase;
+
+/**
+ * Member begin date form plugin.
+ *
+ * @ParForm(
+ *   id = "begin_date",
+ *   title = @Translation("Member begin date.")
+ * )
+ */
+class ParBeginDateForm extends ParFormPluginBase {
+
+  /**
+   * Mapping of the data parameters to the form elements.
+   */
+  protected $formItems = [
+    'par_data_coordinated_business:coordinated_business' => [
+      'date_membership_began' => 'date_membership_began',
+    ],
+  ];
+
+  /**
+   * Load the data for this form.
+   */
+  public function loadData($cardinality = 1) {
+    if ($coordinated_member = $this->getFlowDataHandler()->getParameter('par_data_coordinated_business')) {
+      $this->getFlowDataHandler()->setFormPermValue('date_membership_began', $coordinated_member->get('date_membership_began')->getString());
+    }
+
+    parent::loadData();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getElements($form = [], $cardinality = 1) {
+    // Membership begin date.
+    $form['date_membership_began'] = [
+      '#type' => 'gds_date',
+      '#title' => $this->t('Enter the date the membership began'),
+      '#description' => $this->t('For example: 29/4/2010'),
+      '#default_value' => $this->getDefaultValuesByKey('date_membership_began', $cardinality),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * Validate date field.
+   */
+  public function validateForm(&$form_state, $cardinality = 1) {
+    parent::validate($form_state, $cardinality);
+  }
+}

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParBeginDateForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParBeginDateForm.php
@@ -38,12 +38,14 @@ class ParBeginDateForm extends ParFormPluginBase {
    * {@inheritdoc}
    */
   public function getElements($form = [], $cardinality = 1) {
+    $default_date = ['year' => date('Y'), 'month' => date('m'), 'day' => date('d')];
+
     // Membership begin date.
     $form['date_membership_began'] = [
       '#type' => 'gds_date',
       '#title' => $this->t('Enter the date the membership began'),
       '#description' => $this->t('For example: 29/4/2010'),
-      '#default_value' => $this->getDefaultValuesByKey('date_membership_began', $cardinality),
+      '#default_value' => $this->getDefaultValuesByKey('date_membership_began', $cardinality, $default_date),
     ];
 
     return $form;

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParCoveredByPlanForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParCoveredByPlanForm.php
@@ -27,8 +27,8 @@ class ParCoveredByPlanForm extends ParFormPluginBase {
    * Load the data for this form.
    */
   public function loadData($cardinality = 1) {
-    if ($coordinated_member_bundle = $this->getFlowDataHandler()->getParameter('par_data_coordinated_business')) {
-      $this->getFlowDataHandler()->setFormPermValue('covered_by_inspection', $coordinated_member_bundle->getBoolean('covered_by_inspection'));
+    if ($coordinated_member = $this->getFlowDataHandler()->getParameter('par_data_coordinated_business')) {
+      $this->getFlowDataHandler()->setFormPermValue('covered_by_inspection', $coordinated_member->getBoolean('covered_by_inspection'));
     }
 
     parent::loadData();
@@ -40,7 +40,7 @@ class ParCoveredByPlanForm extends ParFormPluginBase {
   public function getElements($form = [], $cardinality = 1) {
     $coordinated_member_bundle = $this->getParDataManager()->getParBundleEntity('par_data_coordinated_business');
 
-    // Inspection plan coverage
+    // Inspection plan coverage.
     $form['covered_by_inspection'] = [
       '#type' => 'radios',
       '#title' => $this->t('Is this member covered by an inspection plan?'),

--- a/web/modules/custom/par_forms/templates/gds-date.html.twig
+++ b/web/modules/custom/par_forms/templates/gds-date.html.twig
@@ -1,0 +1,7 @@
+<div class="gds_date" style="display: table">
+    <div style="display: table-row">
+        <div class="sub-element" style="display: table-cell"><p class="sub-element-heading">Day</p>{{ element.day }}</div>
+        <div class="sub-element" style="display: table-cell"><p class="sub-element-heading">Month</p>{{ element.month }}</div>
+        <div class="sub-element" style="display: table-cell"><p class="sub-element-heading">Year</p>{{ element.year }}</div>
+    </div>
+</div>

--- a/web/modules/custom/par_forms/templates/gds-date.html.twig
+++ b/web/modules/custom/par_forms/templates/gds-date.html.twig
@@ -1,4 +1,4 @@
-<div class="form-date">
+<div class="form-date form-group">
   <div class="form-group form-group-day">{{ element.day }}</div>
   <div class="form-group form-group-month">{{ element.month }}</div>
   <div class="form-group form-group-year">{{ element.year }}</div>

--- a/web/modules/features/par_data_config/config/install/core.entity_view_display.par_data_coordinated_business.coordinated_business.default.yml
+++ b/web/modules/features/par_data_config/config/install/core.entity_view_display.par_data_coordinated_business.coordinated_business.default.yml
@@ -18,26 +18,26 @@ content:
     type: par_boolean_formatter
     weight: 3
     region: content
-    label: above
+    label: inline
     settings: {  }
     third_party_settings: {  }
   date_membership_began:
     type: datetime_default
     weight: 4
     region: content
-    label: above
+    label: hidden
     settings:
-      format_type: medium
       timezone_override: ''
+      format_type: gds_date_format
     third_party_settings: {  }
   date_membership_ceased:
     type: datetime_default
     weight: 5
     region: content
-    label: above
+    label: hidden
     settings:
-      format_type: medium
       timezone_override: ''
+      format_type: gds_date_format
     third_party_settings: {  }
   field_legal_entity:
     type: entity_reference_entity_view
@@ -45,8 +45,8 @@ content:
     region: content
     label: hidden
     settings:
-      link: true
-      view_mode: default
+      view_mode: summary
+      link: false
     third_party_settings: {  }
   field_organisation:
     weight: 1

--- a/web/modules/features/par_data_config/config/install/core.entity_view_display.par_data_coordinated_business.coordinated_business.full.yml
+++ b/web/modules/features/par_data_config/config/install/core.entity_view_display.par_data_coordinated_business.coordinated_business.full.yml
@@ -1,0 +1,63 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.par_data_coordinated_business.full
+    - field.field.par_data_coordinated_business.coordinated_business.field_legal_entity
+    - field.field.par_data_coordinated_business.coordinated_business.field_organisation
+    - par_data.par_data_coordinated_business_type.coordinated_business
+  module:
+    - datetime
+    - par_data
+id: par_data_coordinated_business.coordinated_business.full
+targetEntityType: par_data_coordinated_business
+bundle: coordinated_business
+mode: full
+content:
+  covered_by_inspection:
+    type: par_boolean_formatter
+    weight: 2
+    region: content
+    label: inline
+    settings: {  }
+    third_party_settings: {  }
+  date_membership_began:
+    type: datetime_default
+    weight: 3
+    region: content
+    label: inline
+    settings:
+      timezone_override: ''
+      format_type: gds_date_format
+    third_party_settings: {  }
+  date_membership_ceased:
+    type: datetime_default
+    weight: 4
+    region: content
+    label: inline
+    settings:
+      timezone_override: ''
+      format_type: gds_date_format
+    third_party_settings: {  }
+  field_legal_entity:
+    type: entity_reference_entity_view
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      view_mode: summary
+      link: false
+    third_party_settings: {  }
+  field_organisation:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: title
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  membership_date: true
+  name: true
+  user_id: true

--- a/web/modules/features/par_data_config/config/install/core.entity_view_display.par_data_coordinated_business.coordinated_business.summary.yml
+++ b/web/modules/features/par_data_config/config/install/core.entity_view_display.par_data_coordinated_business.coordinated_business.summary.yml
@@ -1,0 +1,40 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.par_data_coordinated_business.summary
+    - field.field.par_data_coordinated_business.coordinated_business.field_legal_entity
+    - field.field.par_data_coordinated_business.coordinated_business.field_organisation
+    - par_data.par_data_coordinated_business_type.coordinated_business
+  module:
+    - datetime
+id: par_data_coordinated_business.coordinated_business.summary
+targetEntityType: par_data_coordinated_business
+bundle: coordinated_business
+mode: summary
+content:
+  date_membership_began:
+    type: datetime_default
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      timezone_override: ''
+      format_type: gds_date_format
+    third_party_settings: {  }
+  field_organisation:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: title
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  covered_by_inspection: true
+  date_membership_ceased: true
+  field_legal_entity: true
+  membership_date: true
+  name: true
+  user_id: true

--- a/web/modules/features/par_data_config/config/install/core.entity_view_display.par_data_coordinated_business.coordinated_business.title.yml
+++ b/web/modules/features/par_data_config/config/install/core.entity_view_display.par_data_coordinated_business.coordinated_business.title.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.par_data_coordinated_business.title
+    - field.field.par_data_coordinated_business.coordinated_business.field_legal_entity
+    - field.field.par_data_coordinated_business.coordinated_business.field_organisation
+    - par_data.par_data_coordinated_business_type.coordinated_business
+id: par_data_coordinated_business.coordinated_business.title
+targetEntityType: par_data_coordinated_business
+bundle: coordinated_business
+mode: title
+content:
+  field_organisation:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: title
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  covered_by_inspection: true
+  date_membership_began: true
+  date_membership_ceased: true
+  field_legal_entity: true
+  membership_date: true
+  name: true
+  user_id: true

--- a/web/modules/features/par_data_config/config/install/core.entity_view_mode.par_data_coordinated_business.full.yml
+++ b/web/modules/features/par_data_config/config/install/core.entity_view_mode.par_data_coordinated_business.full.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - par_data
+id: par_data_coordinated_business.full
+label: Full
+targetEntityType: par_data_coordinated_business
+cache: true

--- a/web/modules/features/par_data_config/config/install/core.entity_view_mode.par_data_coordinated_business.summary.yml
+++ b/web/modules/features/par_data_config/config/install/core.entity_view_mode.par_data_coordinated_business.summary.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - par_data
+id: par_data_coordinated_business.summary
+label: Summary
+targetEntityType: par_data_coordinated_business
+cache: true

--- a/web/modules/features/par_data_config/config/install/core.entity_view_mode.par_data_coordinated_business.title.yml
+++ b/web/modules/features/par_data_config/config/install/core.entity_view_mode.par_data_coordinated_business.title.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - par_data
+id: par_data_coordinated_business.title
+label: Title
+targetEntityType: par_data_coordinated_business
+cache: true

--- a/web/modules/features/par_member_add_flows/config/install/par_flows.par_flow.member_add.yml
+++ b/web/modules/features/par_member_add_flows/config/install/par_flows.par_flow.member_add.yml
@@ -70,7 +70,7 @@ steps:
       legal_select: par_member_add_legal_entity
       covered_by: par_member_add_inspection_plan_coverage
     redirect:
-      save: 10
+      save: 9
       cancel: 10
   9:
     route: par_member_add_flows.member_confirmation

--- a/web/modules/features/par_member_add_flows/src/Form/ParConfirmationReviewForm.php
+++ b/web/modules/features/par_member_add_flows/src/Form/ParConfirmationReviewForm.php
@@ -59,6 +59,9 @@ class ParConfirmationReviewForm extends ParBaseForm {
     // Display the member's address
     $form['member_registered_address'] = $this->renderSection('Member business address', $par_data_premises, ['address' => 'summary']);
 
+    // Display the date the membership began.
+    $form['membership_date'] = $this->renderSection('Date of membership', $par_data_coordinated_business, ['date_membership_began' => 'default']);
+
     // Display contacts at the organisation.
     $form['member_contact'] = [
       '#type' => 'fieldset',
@@ -105,6 +108,7 @@ class ParConfirmationReviewForm extends ParBaseForm {
 
     // Get the covered by inspection plan data.
     $membership_start_cid = $this->getFlowNegotiator()->getFormKey('par_member_add_begin_date');
+    $membership_start_date = $this->getFlowDataHandler()->getTempDataValue('date_membership_began', $membership_start_cid);
 
     // Get the covered by inspection plan data.
     $covered_by_cid = $this->getFlowNegotiator()->getFormKey('par_member_add_inspection_plan_coverage');
@@ -147,7 +151,9 @@ class ParConfirmationReviewForm extends ParBaseForm {
     }
 
     // Create the entities.
-    $par_data_coordinated_business = ParDataCoordinatedBusiness::create();
+    $par_data_coordinated_business = ParDataCoordinatedBusiness::create([
+      'date_membership_began' => $membership_start_date,
+    ]);
     $par_data_coordinated_business->get('covered_by_inspection')->setValue($covered_by_inspection_plan);
     $par_data_organisation = ParDataOrganisation::create([
       'organisation_name' => $organisation_name,


### PR DESCRIPTION
## Example:

```
$form['blah'] = [
  '#type' => 'gds_date',
  '#title' => 'blah',
  '#default_value' => ['day' => 12, 'month' => 3, 'year' => 2016],
];
```

## Review Notes:
Ignore everything in the `/sync` directory, this is all in the feature anyway, start review at https://github.com/UKGovernmentBEIS/beis-primary-authority-register/pull/201/files#diff-9b3a6f4e2ccb9d7b1ec36cc6c1aa33eb

And you can almost ignore everything in the feature `par_data_config` because it's all just setting up view displays for the `par_data_coordinated_business` entity which hasn't been done before and is pretty trivial.

## Screenshots:

<img width="1258" alt="messages image 2530489848" src="https://user-images.githubusercontent.com/150512/36272308-0cb68592-1279-11e8-92fa-3eab7d9f66fa.png">

![screenshot from 2018-02-16 16-31-04](https://user-images.githubusercontent.com/334114/36318133-dc6f3938-1336-11e8-9911-71238ce036c2.png)
