### PR TITLE
adding support for GDS date, #title etc

### DIFF
--- a/web/modules/custom/par_forms/src/Element/GdsDate.php
+++ b/web/modules/custom/par_forms/src/Element/GdsDate.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\par_forms\Element;
 
+use Drupal\Core\Render\Element\CompositeFormElementTrait;
+use Drupal\Core\Render\Element\FormElement;
 use Drupal\Core\Render\Element\RenderElement;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
@@ -11,7 +13,9 @@ use Drupal\Core\Render\Element;
  *
  * @FormElement("gds_date")
  */
-class GdsDate extends RenderElement {
+class GdsDate extends FormElement {
+
+  use CompositeFormElementTrait;
 
   /**
    * {@inheritdoc}
@@ -22,11 +26,11 @@ class GdsDate extends RenderElement {
     return [
       '#input' => TRUE,
       '#theme' => 'gds_date',
-      '#label' => 'Enter the date',
-      '#description' => 'The GDS supported date input.',
       '#process' => [[$class, 'processGdsDate']],
-      '#pre_render' => [[$class, 'preRenderGdsDate']],
-      '#theme_wrappers' => ['form_element'],
+      '#pre_render' => [
+        [$class, 'preRenderCompositeFormElement'],
+        [$class, 'preRenderGdsDate'],
+      ],
     ];
   }
 
@@ -34,10 +38,9 @@ class GdsDate extends RenderElement {
    * Prepare the render array for the template.
    */
   public static function preRenderGdsDate($element) {
-    // First name
     $element['day'] = [
       '#type' => 'textfield',
-      '#label' => 'Day',
+      '#title' => 'Day',
       '#attributes' => [
         'name' => $element['#name'] ."_day",
         'pattern' => "[0-9]*",
@@ -47,10 +50,9 @@ class GdsDate extends RenderElement {
       '#required' => $element['#required'],
     ];
 
-    // Last name
     $element['month'] = [
       '#type' => 'textfield',
-      '#label' => 'Month',
+      '#title' => 'Month',
       '#attributes' => [
         'name' => $element['#name'] ."_month",
         'pattern' => "[0-9]*",
@@ -62,7 +64,7 @@ class GdsDate extends RenderElement {
 
     $element['year'] = [
       '#type' => 'textfield',
-      '#label' => 'Year',
+      '#title' => 'Year',
       '#attributes' => [
         'name' => $element['#name'] ."_year",
         'pattern' => "[0-9]*",

--- a/web/modules/custom/par_forms/src/Element/GdsDate.php
+++ b/web/modules/custom/par_forms/src/Element/GdsDate.php
@@ -4,9 +4,7 @@ namespace Drupal\par_forms\Element;
 
 use Drupal\Core\Render\Element\CompositeFormElementTrait;
 use Drupal\Core\Render\Element\FormElement;
-use Drupal\Core\Render\Element\RenderElement;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Render\Element;
 
 /**
  * Provides a GDS Date element.

--- a/web/modules/custom/par_forms/templates/gds-date.html.twig
+++ b/web/modules/custom/par_forms/templates/gds-date.html.twig
@@ -1,7 +1,5 @@
-<div class="gds_date" style="display: table">
-    <div style="display: table-row">
-        <div class="sub-element" style="display: table-cell"><p class="sub-element-heading">Day</p>{{ element.day }}</div>
-        <div class="sub-element" style="display: table-cell"><p class="sub-element-heading">Month</p>{{ element.month }}</div>
-        <div class="sub-element" style="display: table-cell"><p class="sub-element-heading">Year</p>{{ element.year }}</div>
-    </div>
+<div class="form-date">
+  <div class="form-group form-group-day">{{ element.day }}</div>
+  <div class="form-group form-group-month">{{ element.month }}</div>
+  <div class="form-group form-group-year">{{ element.year }}</div>
 </div>


### PR DESCRIPTION
for use…

`$form['blah'] = [
  '#type' => 'gds_date',
  '#title' => 'blah',
];`

<img width="1258" alt="messages image 2530489848" src="https://user-images.githubusercontent.com/150512/36272308-0cb68592-1279-11e8-92fa-3eab7d9f66fa.png">
