### PR TITLE
PAR-1190: Resolving bug with adding new contacts (and advice)

### DIFF
--- a/drupal-update.sh
+++ b/drupal-update.sh
@@ -5,8 +5,7 @@
 if [ -n "$1" ]; then
   ROOT=$1
 else
-  echo "Must pass the project root as the first argument";
-  exit 1;
+  ROOT=$PWD
 fi
 
 echo "Current working directory is ${ROOT}/web"

--- a/sync/par_flows.par_flow.partnership_authority.yml
+++ b/sync/par_flows.par_flow.partnership_authority.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 _core:
-  default_config_hash: L_oxwmcUTb05SW5OR2vu6garwm6-tEVpZQFjDLm2990
+  default_config_hash: llYjwEIYLI66UeFiTYJBJKf6z_A_DczUPhaDltmbcxA
 id: partnership_authority
 label: 'Authority Partnership Flow'
 default_title: null
@@ -68,25 +68,29 @@ steps:
       cancel: 1
   9:
     route: par_partnership_flows.advice_upload_documents
-    form_id: par_partnership_advice_upload
+    form_id: par_partnership_advice_upload_add
     redirect:
       upload: 10
       cancel: 8
   10:
     route: par_partnership_flows.advice_add
     form_id: par_partnership_advice_add
+    form_data:
+      upload: par_partnership_advice_upload_add
     redirect:
       save: 8
       cancel: 8
   11:
     route: par_partnership_flows.advice_edit_documents
-    form_id: par_partnership_advice_upload
+    form_id: par_partnership_advice_upload_edit
     redirect:
       upload: 9
       cancel: 8
   12:
     route: par_partnership_flows.advice_edit
     form_id: par_partnership_advice_edit
+    form_data:
+      upload: par_partnership_advice_upload_edit
     redirect:
       save: 8
       cancel: 8

--- a/sync/par_flows.par_flow.partnership_authority.yml
+++ b/sync/par_flows.par_flow.partnership_authority.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 _core:
-  default_config_hash: uXPJxsQr34_4zvI2APZp5JegCxoa0kAv-wbhVcwh15o
+  default_config_hash: L_oxwmcUTb05SW5OR2vu6garwm6-tEVpZQFjDLm2990
 id: partnership_authority
 label: 'Authority Partnership Flow'
 default_title: null
@@ -31,13 +31,15 @@ steps:
       cancel: 1
   3:
     route: par_partnership_flows.authority_contact_add
-    form_id: par_partnership_contact
+    form_id: par_partnership_contact_add
     redirect:
       save: 4
       cancel: 1
   4:
     route: par_partnership_flows.authority_contact_add_confirm
     form_id: par_partnership_contact_suggestion
+    form_data:
+      contact_form: par_partnership_contact_add
     redirect:
       save: 1
       cancel: 1
@@ -53,7 +55,7 @@ steps:
       done: 1
   7:
     route: par_partnership_flows.authority_contact_edit
-    form_id: par_partnership_contact
+    form_id: par_partnership_contact_edit
     redirect:
       save: 1
       cancel: 1
@@ -66,13 +68,13 @@ steps:
       cancel: 1
   9:
     route: par_partnership_flows.advice_upload_documents
-    form_id: par_partnership_upload
+    form_id: par_partnership_advice_upload
     redirect:
       upload: 10
       cancel: 8
   10:
     route: par_partnership_flows.advice_add
-    form_id: par_partnership_advice
+    form_id: par_partnership_advice_add
     redirect:
       save: 8
       cancel: 8
@@ -84,7 +86,7 @@ steps:
       cancel: 8
   12:
     route: par_partnership_flows.advice_edit
-    form_id: par_partnership_advice
+    form_id: par_partnership_advice_edit
     redirect:
       save: 8
       cancel: 8

--- a/sync/par_flows.par_flow.partnership_coordinated.yml
+++ b/sync/par_flows.par_flow.partnership_coordinated.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 _core:
-  default_config_hash: 8drYQwD1ArK4INjzo3HrvBfsCqGU5m03byvAap0ZSvs
+  default_config_hash: ogHsfhcgKIOOcJb-zQvWZo5hPkVj6MYhjl25jQDE2LY
 id: partnership_coordinated
 label: 'Coordinated Partnership Flow'
 default_title: null
@@ -38,55 +38,57 @@ steps:
       cancel: 1
   3:
     route: par_partnership_flows.address_add
-    form_id: par_partnership_address
+    form_id: par_partnership_address_add
     redirect:
       save: 1
       cancel: 1
   4:
     route: par_partnership_flows.address_edit
-    form_id: par_partnership_address
+    form_id: par_partnership_address_edit
     redirect:
       save: 1
       cancel: 1
   5:
     route: par_partnership_flows.organisation_contact_add
-    form_id: par_partnership_contact
+    form_id: par_partnership_contact_add
     redirect:
       next: 6
       cancel: 1
   6:
     route: par_partnership_flows.organisation_contact_add_confirm
     form_id: par_partnership_contact_suggestion
+    form_data:
+      contact_form: par_partnership_contact_add
     redirect:
       save: 1
       cancel: 1
   7:
     route: par_partnership_flows.organisation_contact_edit
-    form_id: par_partnership_contact
+    form_id: par_partnership_contact_edit
     redirect:
       save: 1
       cancel: 1
   8:
     route: par_partnership_flows.legal_entity_add
-    form_id: par_partnership_legal
+    form_id: par_partnership_legal_add
     redirect:
       save: 1
       cancel: 1
   9:
     route: par_partnership_flows.legal_entity_edit
-    form_id: par_partnership_legal
+    form_id: par_partnership_legal_edit
     redirect:
       save: 1
       cancel: 1
   10:
     route: par_partnership_flows.trading_name_add
-    form_id: par_partnership_trading_name
+    form_id: par_partnership_trading_name_add
     redirect:
       save: 1
       cancel: 1
   11:
     route: par_partnership_flows.trading_name_edit
-    form_id: par_partnership_trading_name
+    form_id: par_partnership_trading_name_edit
     redirect:
       save: 1
       cancel: 1

--- a/sync/par_flows.par_flow.partnership_direct.yml
+++ b/sync/par_flows.par_flow.partnership_direct.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 _core:
-  default_config_hash: Zme6p9Bslb7GO88T7bjcKJeNlYmPLNhM5yPeL2EkwtU
+  default_config_hash: KUftwdVrFnUkpod3Fq6DDoyXp5fQqMZZd0phAlnemXI
 id: partnership_direct
 label: 'Direct Partnership Flow'
 default_title: null
@@ -40,67 +40,69 @@ steps:
       cancel: 1
   3:
     route: par_partnership_flows.address_add
-    form_id: par_partnership_address
+    form_id: par_partnership_address_add
     redirect:
       save: 1
       cancel: 1
   4:
     route: par_partnership_flows.address_edit
-    form_id: par_partnership_address
+    form_id: par_partnership_address_edit
     redirect:
       save: 1
       cancel: 1
   5:
     route: par_partnership_flows.organisation_contact_add
-    form_id: par_partnership_contact
+    form_id: par_partnership_contact_add
     redirect:
       next: 6
       cancel: 1
   6:
     route: par_partnership_flows.organisation_contact_add_confirm
     form_id: par_partnership_contact_suggestion
+    form_data:
+      contact_form: par_partnership_contact_add
     redirect:
       save: 1
       cancel: 1
   7:
     route: par_partnership_flows.organisation_contact_edit
-    form_id: par_partnership_contact
+    form_id: par_partnership_contact_edit
     redirect:
       save: 1
       cancel: 1
   8:
     route: par_partnership_flows.legal_entity_add
-    form_id: par_partnership_legal
+    form_id: par_partnership_legal_add
     redirect:
       save: 1
       cancel: 1
   9:
     route: par_partnership_flows.legal_entity_edit
-    form_id: par_partnership_legal
+    form_id: par_partnership_legal_edit
     redirect:
       save: 1
       cancel: 1
   10:
     route: par_partnership_flows.trading_name_add
-    form_id: par_partnership_trading_name
+    form_id: par_partnership_trading_name_add
     redirect:
       save: 1
       cancel: 1
   11:
     route: par_partnership_flows.trading_name_edit
-    form_id: par_partnership_trading_name
+    form_id: par_partnership_trading_name_edit
     redirect:
       save: 1
       cancel: 1
   12:
     route: par_partnership_flows.sic_code_add
-    form_id: par_partnership_sic_code
+    form_id: par_partnership_sic_code_add
     redirect:
       save: 1
       cancel: 1
   13:
     route: par_partnership_flows.sic_code_edit
-    form_id: par_partnership_sic_code
+    form_id: par_partnership_sic_code_edit
     redirect:
       save: 1
       cancel: 1

--- a/web/modules/custom/par_flows/src/Entity/ParFlow.php
+++ b/web/modules/custom/par_flows/src/Entity/ParFlow.php
@@ -383,6 +383,15 @@ class ParFlow extends ConfigEntityBase implements ParFlowInterface {
   /**
    * {@inheritdoc}
    */
+  public function getStepByFormDataKey($form_data_key, $step = NULL) {
+    $form_data_keys = $this->getStepFormDataKeys($step);
+    return isset($form_data_keys[$form_data_key]) ? $this->getStepByFormId($form_data_keys[$form_data_key]) : NULL;
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
   public function getStepByOperation($index, $operation) {
     $step = $this->getStep($index);
     $redirects = isset($step['redirect']) ? $step['redirect'] : [];
@@ -405,6 +414,20 @@ class ParFlow extends ConfigEntityBase implements ParFlowInterface {
   public function getFormIdByStep($index) {
     $step = $this->getStep($index);
     return isset($step['form_id']) ? $step['form_id'] : NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormIdByCurrentStep() {
+    return $this->getFormIdByStep($this->getCurrentStep());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStepByCurrentFormDataKey($form_data_key) {
+    return $this->getStepByFormDataKey($form_data_key, $this->getCurrentStep());
   }
 
   /**

--- a/web/modules/custom/par_flows/src/Form/ParBaseForm.php
+++ b/web/modules/custom/par_flows/src/Form/ParBaseForm.php
@@ -168,6 +168,15 @@ abstract class ParBaseForm extends FormBase implements ParBaseInterface {
   /**
    * {@inheritdoc}
    */
+  public function getFormId() {
+    if ($form_id = $this->getFlowNegotiator()->getFlow()->getFormIdByCurrentStep()) {
+      return $form_id;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function buildForm(array $form, FormStateInterface $form_state) {
     // Add all the registered components to the form.
     foreach ($this->getComponents() as $component) {
@@ -424,7 +433,7 @@ abstract class ParBaseForm extends FormBase implements ParBaseInterface {
     // Always store the values whenever we submit the form.
     $values = $this->cleanseFormDefaults($form_state->getValues());
     $values = $this->cleanseMultipleValues($values);
-    $this->getFlowDataHandler()->setFormTempData($values);
+    $this->getFlowDataHandler()->mergeFormTempData($values);
 
     // Set the redirect to the next form based on the flow configuration 'operation'
     // parameter that matches the submit button's name.
@@ -440,7 +449,7 @@ abstract class ParBaseForm extends FormBase implements ParBaseInterface {
     // Always store the values whenever we submit the form.
     $values = $this->cleanseFormDefaults($form_state->getValues());
     $values = $this->cleanseMultipleValues($values);
-    $this->getFlowDataHandler()->setFormTempData($values);
+    $this->getFlowDataHandler()->mergeFormTempData($values);
   }
 
   /**
@@ -450,7 +459,7 @@ abstract class ParBaseForm extends FormBase implements ParBaseInterface {
     // Always store the values whenever we submit the form.
     $values = $this->cleanseFormDefaults($form_state->getValues());
     $values = $this->cleanseMultipleValues($values);
-    $this->getFlowDataHandler()->setFormTempData($values);
+    $this->getFlowDataHandler()->mergeFormTempData($values);
 
     list($button, $plugin_id, $cardinality) = explode(':', $form_state->getTriggeringElement()['#name']);
     $values = $form_state->getValue(ParFormBuilder::PAR_COMPONENT_PREFIX . $plugin_id);
@@ -471,7 +480,7 @@ abstract class ParBaseForm extends FormBase implements ParBaseInterface {
     // Resave the values based on the newly removed items.
     $values = $this->cleanseFormDefaults($form_state->getValues());
     $values = $this->cleanseMultipleValues($values);
-    $this->getFlowDataHandler()->setFormTempData($values);
+    $this->getFlowDataHandler()->mergeFormTempData($values);
   }
 
   /**

--- a/web/modules/custom/par_flows/src/Form/ParBaseForm.php
+++ b/web/modules/custom/par_flows/src/Form/ParBaseForm.php
@@ -433,7 +433,7 @@ abstract class ParBaseForm extends FormBase implements ParBaseInterface {
     // Always store the values whenever we submit the form.
     $values = $this->cleanseFormDefaults($form_state->getValues());
     $values = $this->cleanseMultipleValues($values);
-    $this->getFlowDataHandler()->mergeFormTempData($values);
+    $this->getFlowDataHandler()->setFormTempData($values);
 
     // Set the redirect to the next form based on the flow configuration 'operation'
     // parameter that matches the submit button's name.
@@ -449,7 +449,7 @@ abstract class ParBaseForm extends FormBase implements ParBaseInterface {
     // Always store the values whenever we submit the form.
     $values = $this->cleanseFormDefaults($form_state->getValues());
     $values = $this->cleanseMultipleValues($values);
-    $this->getFlowDataHandler()->mergeFormTempData($values);
+    $this->getFlowDataHandler()->setFormTempData($values);
   }
 
   /**
@@ -459,7 +459,7 @@ abstract class ParBaseForm extends FormBase implements ParBaseInterface {
     // Always store the values whenever we submit the form.
     $values = $this->cleanseFormDefaults($form_state->getValues());
     $values = $this->cleanseMultipleValues($values);
-    $this->getFlowDataHandler()->mergeFormTempData($values);
+    $this->getFlowDataHandler()->setFormTempData($values);
 
     list($button, $plugin_id, $cardinality) = explode(':', $form_state->getTriggeringElement()['#name']);
     $values = $form_state->getValue(ParFormBuilder::PAR_COMPONENT_PREFIX . $plugin_id);
@@ -480,7 +480,7 @@ abstract class ParBaseForm extends FormBase implements ParBaseInterface {
     // Resave the values based on the newly removed items.
     $values = $this->cleanseFormDefaults($form_state->getValues());
     $values = $this->cleanseMultipleValues($values);
-    $this->getFlowDataHandler()->mergeFormTempData($values);
+    $this->getFlowDataHandler()->setFormTempData($values);
   }
 
   /**

--- a/web/modules/custom/par_flows/src/ParFlowDataHandler.php
+++ b/web/modules/custom/par_flows/src/ParFlowDataHandler.php
@@ -187,28 +187,6 @@ class ParFlowDataHandler implements ParFlowDataHandlerInterface {
   /**
    * {@inheritdoc}
    */
-  public function mergeFormTempData(array $data, $cid = NULL) {
-    $existing = $this->getFormTempData($cid);
-
-    if (empty($data)) {
-      return;
-    }
-    elseif (empty($existing)) {
-      $values = $data;
-    }
-    elseif ($existing === $data) {
-      return;
-    }
-    else {
-      $values = NestedArray::mergeDeep($existing, $data);
-    }
-
-    $this->setFormTempData($values, $cid);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function deleteFormTempData($cid = NULL) {
     $cid = empty($cid) ? $this->negotiator->getFlowKey() : $cid;
 

--- a/web/modules/custom/par_flows/src/ParFlowDataHandler.php
+++ b/web/modules/custom/par_flows/src/ParFlowDataHandler.php
@@ -187,6 +187,28 @@ class ParFlowDataHandler implements ParFlowDataHandlerInterface {
   /**
    * {@inheritdoc}
    */
+  public function mergeFormTempData(array $data, $cid = NULL) {
+    $existing = $this->getFormTempData($cid);
+
+    if (empty($data)) {
+      return;
+    }
+    elseif (empty($existing)) {
+      $values = $data;
+    }
+    elseif ($existing === $data) {
+      return;
+    }
+    else {
+      $values = NestedArray::mergeDeep($existing, $data);
+    }
+
+    $this->setFormTempData($values, $cid);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function deleteFormTempData($cid = NULL) {
     $cid = empty($cid) ? $this->negotiator->getFlowKey() : $cid;
 

--- a/web/modules/custom/par_flows/src/ParFlowNegotiator.php
+++ b/web/modules/custom/par_flows/src/ParFlowNegotiator.php
@@ -135,7 +135,15 @@ class ParFlowNegotiator implements ParFlowNegotiatorInterface {
     $flow_name = !empty($flow_name) ? $flow_name : $this->getFlowName();
 
     $flow = $this->getFlow($flow_name);
-    $step = $flow->getStepByFormId($form_id);
+
+    // If the form_id represents a form_data key get the step based on that key.
+    // This is useful for situations where the form_id is ambiguous (used more than once) in the flow.
+    $step = $flow->getStepByCurrentFormDataKey($form_id);
+    // Otherwise look for the form_id in the flow.
+    if (!$step) {
+      $step = $flow->getStepByFormId($form_id);
+    }
+
     $route_name = $flow->getRouteByStep($step);
 
     return $this->getFlowKey($route_name, $state, $flow_name);

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementAddActionForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementAddActionForm.php
@@ -30,13 +30,6 @@ class ParEnforcementAddActionForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_enforcement_notice_add_action';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function titleCallback() {
 
     $par_data_partnership = $this->getFlowDataHandler()->getParameter('par_data_partnership');

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementApproveNoticeForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementApproveNoticeForm.php
@@ -22,13 +22,6 @@ class ParEnforcementApproveNoticeForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_enforcement_notice_approve';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function titleCallback() {
     $this->pageTitle =  "Make a decision | Proposed enforcement action(s)";
     return parent::titleCallback();

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementConfirmNoticeForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementConfirmNoticeForm.php
@@ -44,13 +44,6 @@ class ParEnforcementConfirmNoticeForm extends ParBaseForm {
   }
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_enforcement_notice_approve_confirm';
-  }
-
-  /**
    * Helper to get all the editable values when editing or
    * revisiting a previously edited page.
    */

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementEnforceOrganisationForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementEnforceOrganisationForm.php
@@ -21,13 +21,6 @@ class ParEnforcementEnforceOrganisationForm extends ParBaseForm {
   protected $flow = 'raise_enforcement';
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_enforce_organisation';
-  }
-
-  /**
    * Helper to get all the editable values when editing or
    * revisiting a previously edited page.
    *

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementOfficerDetailsForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementOfficerDetailsForm.php
@@ -17,13 +17,6 @@ class ParEnforcementOfficerDetailsForm extends ParBaseEnforcementForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_enforcement_officer_details';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function titleCallback() {
 
     $enforcementFlowTitle = $this->RaiseEnforcementTitleCallback();

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementRaiseNoticeDetailsForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementRaiseNoticeDetailsForm.php
@@ -29,13 +29,6 @@ class ParEnforcementRaiseNoticeDetailsForm extends ParBaseEnforcementForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_enforcement_notice_raise_details';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function titleCallback() {
     $enforcementFlowTitle = $this->RaiseEnforcementTitleCallback();
     if ($enforcementFlowTitle) {

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementRaiseNoticeForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementRaiseNoticeForm.php
@@ -19,13 +19,6 @@ class ParEnforcementRaiseNoticeForm extends ParBaseEnforcementForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_enforcement_notice_raise';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function titleCallback() {
 
     $enforcementFlowTitle = $this->RaiseEnforcementTitleCallback();

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementReferredAuthorityForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementReferredAuthorityForm.php
@@ -18,13 +18,6 @@ class ParEnforcementReferredAuthorityForm extends ParBaseForm {
   protected $flow = 'approve_enforcement';
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_enforcement_referred_authority';
-  }
-
-  /**
    * Helper to get all the editable values when editing or
    * revisiting a previously edited page.
    */

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementSendNoticeForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementSendNoticeForm.php
@@ -17,13 +17,6 @@ class ParEnforcementSendNoticeForm extends ParBaseForm {
   protected $flow = 'send_enforcement';
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_enforcement_notice_send';
-  }
-
-  /**
    * Helper to get all the editable values when editing or
    * revisiting a previously edited page.
    */

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementSubmitNoticeForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementSubmitNoticeForm.php
@@ -22,13 +22,6 @@ class ParEnforcementSubmitNoticeForm extends ParBaseEnforcementForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_enforcement_notice_raise_confirm';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function titleCallback() {
 
     $par_data_enforcement_notice = $this->getFlowDataHandler()->getParameter('par_data_enforcement_notice');

--- a/web/modules/features/par_member_add_flows/src/Form/ParAddressForm.php
+++ b/web/modules/features/par_member_add_flows/src/Form/ParAddressForm.php
@@ -19,11 +19,4 @@ class ParAddressForm extends ParBaseForm {
    */
   protected $pageTitle = 'Add member organisation address';
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_member_add_address';
-  }
-
 }

--- a/web/modules/features/par_member_add_flows/src/Form/ParConfirmationReviewForm.php
+++ b/web/modules/features/par_member_add_flows/src/Form/ParConfirmationReviewForm.php
@@ -25,13 +25,6 @@ class ParConfirmationReviewForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_member_add_review';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   protected $pageTitle = 'Member summary';
 
   /**

--- a/web/modules/features/par_member_add_flows/src/Form/ParContactForm.php
+++ b/web/modules/features/par_member_add_flows/src/Form/ParContactForm.php
@@ -18,11 +18,4 @@ class ParContactForm extends ParBaseForm {
    */
   protected $pageTitle = 'Add member contact details';
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_member_add_contact';
-  }
-
 }

--- a/web/modules/features/par_member_add_flows/src/Form/ParCoveredByPlanForm.php
+++ b/web/modules/features/par_member_add_flows/src/Form/ParCoveredByPlanForm.php
@@ -18,11 +18,4 @@ class ParCoveredByPlanForm extends ParBaseForm {
    */
   protected $pageTitle = "Inspection plan coverage";
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_member_add_inspection_plan_coverage';
-  }
-
 }

--- a/web/modules/features/par_member_add_flows/src/Form/ParLegalEntityForm.php
+++ b/web/modules/features/par_member_add_flows/src/Form/ParLegalEntityForm.php
@@ -18,11 +18,4 @@ class ParLegalEntityForm extends ParBaseForm {
    */
   protected $pageTitle = 'Add legal entities';
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_member_add_legal_entity';
-  }
-
 }

--- a/web/modules/features/par_member_add_flows/src/Form/ParOrganisationNameForm.php
+++ b/web/modules/features/par_member_add_flows/src/Form/ParOrganisationNameForm.php
@@ -22,13 +22,6 @@ class ParOrganisationNameForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_member_add_organisation_name';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function buildForm(array $form, FormStateInterface $form_state) {
 
     $form['organisation_name'] = [

--- a/web/modules/features/par_member_add_flows/src/Form/ParStartDateForm.php
+++ b/web/modules/features/par_member_add_flows/src/Form/ParStartDateForm.php
@@ -18,11 +18,4 @@ class ParStartDateForm extends ParBaseForm {
    */
   protected $pageTitle = "Enter the date the membership began";
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_member_add_begin_date';
-  }
-
 }

--- a/web/modules/features/par_member_add_flows/src/Form/ParTradingForm.php
+++ b/web/modules/features/par_member_add_flows/src/Form/ParTradingForm.php
@@ -19,11 +19,4 @@ class ParTradingForm extends ParBaseForm {
    */
   protected $pageTitle = "Add trading name";
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_member_add_trading_name';
-  }
-
 }

--- a/web/modules/features/par_member_upload_flows/src/Form/ParMemberConfirmUploadFlowsForm.php
+++ b/web/modules/features/par_member_upload_flows/src/Form/ParMemberConfirmUploadFlowsForm.php
@@ -17,13 +17,6 @@ class ParMemberConfirmUploadFlowsForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_member_upload_csv_confirm';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function buildForm(array $form, FormStateInterface $form_state, ParDataPartnership $par_data_partnership = NULL) {
 
     // Upload csv file confirmation message.

--- a/web/modules/features/par_member_upload_flows/src/Form/ParMemberSuccessUploadFlowsForm.php
+++ b/web/modules/features/par_member_upload_flows/src/Form/ParMemberSuccessUploadFlowsForm.php
@@ -17,13 +17,6 @@ class ParMemberSuccessUploadFlowsForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_member_upload_csv_success';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function buildForm(array $form, FormStateInterface $form_state, ParDataPartnership $par_data_partnership = NULL) {
 
     // Upload csv file success message.

--- a/web/modules/features/par_member_upload_flows/src/Form/ParMemberUploadFlowsForm.php
+++ b/web/modules/features/par_member_upload_flows/src/Form/ParMemberUploadFlowsForm.php
@@ -18,13 +18,6 @@ class ParMemberUploadFlowsForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_member_upload_csv';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function buildForm(array $form, FormStateInterface $form_state, ParDataPartnership $par_data_partnership = NULL) {
     // Multiple file field.
     $form['csv'] = [

--- a/web/modules/features/par_partnership_confirmation_flows/src/Form/ParAboutBusinessForm.php
+++ b/web/modules/features/par_partnership_confirmation_flows/src/Form/ParAboutBusinessForm.php
@@ -19,13 +19,6 @@ class ParAboutBusinessForm extends ParBaseForm {
   protected $pageTitle = 'Confirm the details about the business';
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_confirmation_about_business';
-  }
-
-  /**
    * Load the data for this form.
    */
   public function loadData() {

--- a/web/modules/features/par_partnership_confirmation_flows/src/Form/ParAddressForm.php
+++ b/web/modules/features/par_partnership_confirmation_flows/src/Form/ParAddressForm.php
@@ -20,13 +20,6 @@ class ParAddressForm extends ParBaseForm {
   protected $pageTitle = 'Confirm the primary contact details';
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_confirmation_address';
-  }
-
-  /**
    * Load the data for this form.
    */
   public function loadData() {

--- a/web/modules/features/par_partnership_confirmation_flows/src/Form/ParBusinessSizeForm.php
+++ b/web/modules/features/par_partnership_confirmation_flows/src/Form/ParBusinessSizeForm.php
@@ -20,13 +20,6 @@ class ParBusinessSizeForm extends ParBaseForm {
   protected $pageTitle = 'Confirm the size of the membership list';
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_confirmation_business_size';
-  }
-
-  /**
    * Load the data for this form.
    */
   public function loadData() {

--- a/web/modules/features/par_partnership_confirmation_flows/src/Form/ParConfirmationReviewForm.php
+++ b/web/modules/features/par_partnership_confirmation_flows/src/Form/ParConfirmationReviewForm.php
@@ -24,13 +24,6 @@ class ParConfirmationReviewForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_partnership_confirmation_review';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   protected $pageTitle = 'Review the partnership summary information below';
 
   /**

--- a/web/modules/features/par_partnership_confirmation_flows/src/Form/ParContactForm.php
+++ b/web/modules/features/par_partnership_confirmation_flows/src/Form/ParContactForm.php
@@ -20,13 +20,6 @@ class ParContactForm extends ParBaseForm {
   protected $pageTitle = 'Confirm the primary contact details';
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_confirmation_contact';
-  }
-
-  /**
    * Load the data for this form.
    */
   public function loadData() {

--- a/web/modules/features/par_partnership_confirmation_flows/src/Form/ParEmployeeNumberForm.php
+++ b/web/modules/features/par_partnership_confirmation_flows/src/Form/ParEmployeeNumberForm.php
@@ -20,13 +20,6 @@ class ParEmployeeNumberForm extends ParBaseForm {
   protected $pageTitle = "Confirm number of employees";
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_confirmation_employee_number';
-  }
-
-  /**
    * Load the data for this form.
    */
   public function loadData() {

--- a/web/modules/features/par_partnership_confirmation_flows/src/Form/ParLegalEntityForm.php
+++ b/web/modules/features/par_partnership_confirmation_flows/src/Form/ParLegalEntityForm.php
@@ -22,13 +22,6 @@ class ParLegalEntityForm extends ParBaseForm {
   protected $pageTitle = 'Confirm the legal entity';
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_confirmation_add_legal_entity';
-  }
-
-  /**
    * Load the data for this form.
    */
   public function loadData() {

--- a/web/modules/features/par_partnership_confirmation_flows/src/Form/ParSelectLegalEntitiesForm.php
+++ b/web/modules/features/par_partnership_confirmation_flows/src/Form/ParSelectLegalEntitiesForm.php
@@ -18,13 +18,6 @@ class ParSelectLegalEntitiesForm extends ParBaseForm {
   protected $pageTitle = 'Choose the legal entities for the partnership';
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_confirmation_select_legal_entities';
-  }
-
-  /**
    * Load the data for this form.
    */
   public function loadData() {

--- a/web/modules/features/par_partnership_confirmation_flows/src/Form/ParSicCodeForm.php
+++ b/web/modules/features/par_partnership_confirmation_flows/src/Form/ParSicCodeForm.php
@@ -19,13 +19,6 @@ class ParSicCodeForm extends ParBaseForm {
   protected $pageTitle = "Confirm the SIC code";
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_confirmation_sic_code';
-  }
-
-  /**
    * Load the data for this form.
    */
   public function loadData() {

--- a/web/modules/features/par_partnership_confirmation_flows/src/Form/ParTradingForm.php
+++ b/web/modules/features/par_partnership_confirmation_flows/src/Form/ParTradingForm.php
@@ -19,13 +19,6 @@ class ParTradingForm extends ParBaseForm {
   protected $pageTitle = "Confirm the trading name";
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_confirmation_trading_name';
-  }
-
-  /**
    * Load the data for this form.
    */
   public function loadData() {

--- a/web/modules/features/par_partnership_flows/config/install/par_flows.par_flow.partnership_authority.yml
+++ b/web/modules/features/par_partnership_flows/config/install/par_flows.par_flow.partnership_authority.yml
@@ -28,13 +28,15 @@ steps:
       cancel: 1
   3:
     route: par_partnership_flows.authority_contact_add
-    form_id: par_partnership_contact
+    form_id: par_partnership_contact_add
     redirect:
       save: 4
       cancel: 1
   4:
     route: par_partnership_flows.authority_contact_add_confirm
     form_id: par_partnership_contact_suggestion
+    form_data:
+      contact_form: par_partnership_contact_add
     redirect:
       save: 1
       cancel: 1
@@ -50,7 +52,7 @@ steps:
       done: 1
   7:
     route: par_partnership_flows.authority_contact_edit
-    form_id: par_partnership_contact
+    form_id: par_partnership_contact_edit
     redirect:
       save: 1
       cancel: 1
@@ -63,13 +65,13 @@ steps:
       cancel: 1
   9:
     route: par_partnership_flows.advice_upload_documents
-    form_id: par_partnership_upload
+    form_id: par_partnership_advice_upload
     redirect:
       upload: 10
       cancel: 8
   10:
     route: par_partnership_flows.advice_add
-    form_id: par_partnership_advice
+    form_id: par_partnership_advice_add
     redirect:
       save: 8
       cancel: 8
@@ -81,7 +83,7 @@ steps:
       cancel: 8
   12:
     route: par_partnership_flows.advice_edit
-    form_id: par_partnership_advice
+    form_id: par_partnership_advice_edit
     redirect:
       save: 8
       cancel: 8

--- a/web/modules/features/par_partnership_flows/config/install/par_flows.par_flow.partnership_authority.yml
+++ b/web/modules/features/par_partnership_flows/config/install/par_flows.par_flow.partnership_authority.yml
@@ -65,25 +65,29 @@ steps:
       cancel: 1
   9:
     route: par_partnership_flows.advice_upload_documents
-    form_id: par_partnership_advice_upload
+    form_id: par_partnership_advice_upload_add
     redirect:
       upload: 10
       cancel: 8
   10:
     route: par_partnership_flows.advice_add
     form_id: par_partnership_advice_add
+    form_data:
+      upload: par_partnership_advice_upload_add
     redirect:
       save: 8
       cancel: 8
   11:
     route: par_partnership_flows.advice_edit_documents
-    form_id: par_partnership_advice_upload
+    form_id: par_partnership_advice_upload_edit
     redirect:
       upload: 9
       cancel: 8
   12:
     route: par_partnership_flows.advice_edit
     form_id: par_partnership_advice_edit
+    form_data:
+      upload: par_partnership_advice_upload_edit
     redirect:
       save: 8
       cancel: 8

--- a/web/modules/features/par_partnership_flows/config/install/par_flows.par_flow.partnership_coordinated.yml
+++ b/web/modules/features/par_partnership_flows/config/install/par_flows.par_flow.partnership_coordinated.yml
@@ -35,55 +35,57 @@ steps:
       cancel: 1
   3:
     route: par_partnership_flows.address_add
-    form_id: par_partnership_address
+    form_id: par_partnership_address_add
     redirect:
       save: 1
       cancel: 1
   4:
     route: par_partnership_flows.address_edit
-    form_id: par_partnership_address
+    form_id: par_partnership_address_edit
     redirect:
       save: 1
       cancel: 1
   5:
     route: par_partnership_flows.organisation_contact_add
-    form_id: par_partnership_contact
+    form_id: par_partnership_contact_add
     redirect:
       next: 6
       cancel: 1
   6:
     route: par_partnership_flows.organisation_contact_add_confirm
     form_id: par_partnership_contact_suggestion
+    form_data:
+      contact_form: par_partnership_contact_add
     redirect:
       save: 1
       cancel: 1
   7:
     route: par_partnership_flows.organisation_contact_edit
-    form_id: par_partnership_contact
+    form_id: par_partnership_contact_edit
     redirect:
       save: 1
       cancel: 1
   8:
     route: par_partnership_flows.legal_entity_add
-    form_id: par_partnership_legal
+    form_id: par_partnership_legal_add
     redirect:
       save: 1
       cancel: 1
   9:
     route: par_partnership_flows.legal_entity_edit
-    form_id: par_partnership_legal
+    form_id: par_partnership_legal_edit
     redirect:
       save: 1
       cancel: 1
   10:
     route: par_partnership_flows.trading_name_add
-    form_id: par_partnership_trading_name
+    form_id: par_partnership_trading_name_add
     redirect:
       save: 1
       cancel: 1
   11:
     route: par_partnership_flows.trading_name_edit
-    form_id: par_partnership_trading_name
+    form_id: par_partnership_trading_name_edit
     redirect:
       save: 1
       cancel: 1

--- a/web/modules/features/par_partnership_flows/config/install/par_flows.par_flow.partnership_direct.yml
+++ b/web/modules/features/par_partnership_flows/config/install/par_flows.par_flow.partnership_direct.yml
@@ -37,67 +37,69 @@ steps:
       cancel: 1
   3:
     route: par_partnership_flows.address_add
-    form_id: par_partnership_address
+    form_id: par_partnership_address_add
     redirect:
       save: 1
       cancel: 1
   4:
     route: par_partnership_flows.address_edit
-    form_id: par_partnership_address
+    form_id: par_partnership_address_edit
     redirect:
       save: 1
       cancel: 1
   5:
     route: par_partnership_flows.organisation_contact_add
-    form_id: par_partnership_contact
+    form_id: par_partnership_contact_add
     redirect:
       next: 6
       cancel: 1
   6:
     route: par_partnership_flows.organisation_contact_add_confirm
     form_id: par_partnership_contact_suggestion
+    form_data:
+      contact_form: par_partnership_contact_add
     redirect:
       save: 1
       cancel: 1
   7:
     route: par_partnership_flows.organisation_contact_edit
-    form_id: par_partnership_contact
+    form_id: par_partnership_contact_edit
     redirect:
       save: 1
       cancel: 1
   8:
     route: par_partnership_flows.legal_entity_add
-    form_id: par_partnership_legal
+    form_id: par_partnership_legal_add
     redirect:
       save: 1
       cancel: 1
   9:
     route: par_partnership_flows.legal_entity_edit
-    form_id: par_partnership_legal
+    form_id: par_partnership_legal_edit
     redirect:
       save: 1
       cancel: 1
   10:
     route: par_partnership_flows.trading_name_add
-    form_id: par_partnership_trading_name
+    form_id: par_partnership_trading_name_add
     redirect:
       save: 1
       cancel: 1
   11:
     route: par_partnership_flows.trading_name_edit
-    form_id: par_partnership_trading_name
+    form_id: par_partnership_trading_name_edit
     redirect:
       save: 1
       cancel: 1
   12:
     route: par_partnership_flows.sic_code_add
-    form_id: par_partnership_sic_code
+    form_id: par_partnership_sic_code_add
     redirect:
       save: 1
       cancel: 1
   13:
     route: par_partnership_flows.sic_code_edit
-    form_id: par_partnership_sic_code
+    form_id: par_partnership_sic_code_edit
     redirect:
       save: 1
       cancel: 1

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAboutBusinessForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAboutBusinessForm.php
@@ -19,13 +19,6 @@ class ParPartnershipFlowsAboutBusinessForm extends ParBaseForm {
   protected $pageTitle = 'Information about the business';
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_about_business';
-  }
-
-  /**
    * Helper to get all the editable values.
    *
    * Used for when editing or revisiting a previously edited page.

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAboutForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAboutForm.php
@@ -25,13 +25,6 @@ class ParPartnershipFlowsAboutForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_partnership_about';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function titleCallback() {
     $this->pageTitle = 'Information about the new partnership';
 

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAddressForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAddressForm.php
@@ -37,13 +37,6 @@ class ParPartnershipFlowsAddressForm extends ParBaseForm {
   ];
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_address';
-  }
-
-  /**
    * Get partnership.
    */
   public function getPartnershipParam() {

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAdviceForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAdviceForm.php
@@ -72,8 +72,19 @@ class ParPartnershipFlowsAdviceForm extends ParBaseForm {
     $this->retrieveEditableValues($par_data_partnership, $par_data_advice);
     $advice_bundle = $this->getParDataManager()->getParBundleEntity('par_data_advice');
 
-    // Get files from "par_partnership_advice_upload" step.
-    $cid = $this->getFlowNegotiator()->getFormKey('par_partnership_advice_upload');
+    // Get files from "upload" step.
+    // To use this form there must be a "form_data['upload']" key in the step configuration:
+    // 1:
+    //   route: example.route_name
+    //   form_id: form_id_where_file_is_uplaoded
+    //   form_data:
+    //     upload: par_partnership_advice_upload_edit
+    // 2:
+    //   route: example.route_name_2
+    //   form_id: example_form_id
+    //   form_data:
+    //     upload: form_id_where_file_is_uplaoded
+    $cid = $this->getFlowNegotiator()->getFormKey('upload');
     $files = $this->getFlowDataHandler()->getDefaultValues("files", '', $cid);
     if ($files) {
       // Show files.
@@ -152,8 +163,19 @@ class ParPartnershipFlowsAdviceForm extends ParBaseForm {
     // Get the advice entity from the URL.
     $par_data_advice = $this->getFlowDataHandler()->getParameter('par_data_advice');
 
-    // Get files from "par_partnership_advice_upload" step.
-    $cid = $this->getFlowNegotiator()->getFormKey('par_partnership_advice_upload');
+    // Get files from "upload" step.
+    // To use this form there must be a "form_data['upload']" key in the step configuration:
+    // 1:
+    //   route: example.route_name
+    //   form_id: form_id_where_file_is_uplaoded
+    //   form_data:
+    //     upload: par_partnership_advice_upload_edit
+    // 2:
+    //   route: example.route_name_2
+    //   form_id: example_form_id
+    //   form_data:
+    //     upload: form_id_where_file_is_uplaoded
+    $cid = $this->getFlowNegotiator()->getFormKey('upload');
     $files = $this->getFlowDataHandler()->getDefaultValues('files', [], $cid);
 
     // Add all the uploaded files from the upload form to the advice and save.

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAdviceForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAdviceForm.php
@@ -20,13 +20,6 @@ class ParPartnershipFlowsAdviceForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_partnership_advice';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   protected $formItems = [
     'par_data_advice:advice' => [
       'advice_type' => 'advice_type',

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAdviceUploadForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAdviceUploadForm.php
@@ -20,13 +20,6 @@ class ParPartnershipFlowsAdviceUploadForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_partnership_advice_upload';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function titleCallback() {
     return "Primary Authority Advice | Edit document type and regulatory functions";
   }

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsApplicationAuthorityChecklistForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsApplicationAuthorityChecklistForm.php
@@ -17,13 +17,6 @@ class ParPartnershipFlowsApplicationAuthorityChecklistForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_partnership_application_authority_checklist';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function retrieveEditableValues() {
 
   }

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsApplicationConfirmationForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsApplicationConfirmationForm.php
@@ -21,13 +21,6 @@ class ParPartnershipFlowsApplicationConfirmationForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_partnership_application_confirmation';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function titleCallback() {
     $par_data_partnership = $this->getFlowDataHandler()->getParameter('par_data_partnership');
     if ($par_data_partnership) {

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsApplicationOrganisationForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsApplicationOrganisationForm.php
@@ -27,13 +27,6 @@ class ParPartnershipFlowsApplicationOrganisationForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_partnership_application_organisation';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function buildForm(array $form, FormStateInterface $form_state) {
 
     $form['organisation_name'] = [

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsApplicationTypeForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsApplicationTypeForm.php
@@ -25,13 +25,6 @@ class ParPartnershipFlowsApplicationTypeForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_partnership_application_type';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function retrieveEditableValues() {
 
   }

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAuthoritySuggestionForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAuthoritySuggestionForm.php
@@ -19,13 +19,6 @@ class ParPartnershipFlowsAuthoritySuggestionForm extends ParBaseForm {
   protected $pageTitle = 'Which authority are you acting on behalf of?';
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_authority_selection';
-  }
-
-  /**
    * Helper to get all the editable values when editing or
    * revisiting a previously edited page.
    *

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsBusinessSizeForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsBusinessSizeForm.php
@@ -16,13 +16,6 @@ class ParPartnershipFlowsBusinessSizeForm extends ParBaseForm {
   use ParPartnershipFlowsTrait;
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_business_size';
-  }
-
-  /**
    * Helper to get all the editable values when editing or
    * revisiting a previously edited page.
    *

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsContactForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsContactForm.php
@@ -36,13 +36,6 @@ class ParPartnershipFlowsContactForm extends ParBaseForm {
   ];
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_contact';
-  }
-
-  /**
    * Get partnership.
    */
   public function getPartnershipParam() {
@@ -187,8 +180,8 @@ class ParPartnershipFlowsContactForm extends ParBaseForm {
       $par_data_person->set('communication_mobile', $mobile_phone_preference_value);
 
       if ($par_data_person->save()) {
-        // Only delete the form data for the par_partnership_contact form.
-        $this->getFlowDataHandler()->deleteFormTempData('par_partnership_contact');
+        // Only delete the form data for the current form.
+        $this->getFlowDataHandler()->deleteFormTempData();
       }
       else {
         $message = $this->t('This %person could not be saved for %form_id');

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsContactSuggestionForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsContactSuggestionForm.php
@@ -24,13 +24,6 @@ class ParPartnershipFlowsContactSuggestionForm extends ParBaseForm {
   protected $par_data_person_id;
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_contact_suggestion';
-  }
-
-  /**
    * Helper to get all the editable values when editing or
    * revisiting a previously edited page.
    *
@@ -46,7 +39,7 @@ class ParPartnershipFlowsContactSuggestionForm extends ParBaseForm {
    */
   public function buildForm(array $form, FormStateInterface $form_state, ParDataPartnership $par_data_partnership = NULL) {
 
-    $cid = $this->getFlowNegotiator()->getFormKey('par_partnership_contact');
+    $cid = $this->getFlowNegotiator()->getFormKey('contact_form');
     $conditions = [
       'name' => [
         'AND' => [
@@ -117,12 +110,10 @@ class ParPartnershipFlowsContactSuggestionForm extends ParBaseForm {
 
     // Get partnership entity from URL.
     $par_data_partnership = $this->getFlowDataHandler()->getParameter('par_data_partnership');
-
-    $cid = $this->getFlowNegotiator()->getFormKey('par_partnership_contact_suggestion');
-    if ($this->getFlowDataHandler()->getDefaultValues('par_data_person_id', '', $cid) === 'new') {
+    if ($this->getFlowDataHandler()->getDefaultValues('par_data_person_id') === 'new') {
 
       // Create new person entity.
-      $cid = $this->getFlowNegotiator()->getFormKey('par_partnership_contact');
+      $cid = $this->getFlowNegotiator()->getFormKey('contact_form');
       $par_data_person = ParDataPerson::create([
         'type' => 'person',
         'salutation' => $this->getFlowDataHandler()->getTempDataValue('salutation', $cid),
@@ -134,7 +125,6 @@ class ParPartnershipFlowsContactSuggestionForm extends ParBaseForm {
         'communication_notes' => $this->getFlowDataHandler()->getTempDataValue('notes', $cid)
       ]);
 
-      // @todo refactor this to use $this->getFlowDataHandler()->getTempDataBooleanValue() or similar.
       // Save the email preference.
       $email_preference_value = isset($this->getFlowDataHandler()->getTempDataValue('preferred_contact', $cid)['communication_email'])
         && !empty($this->getFlowDataHandler()->getTempDataValue('preferred_contact', $cid)['communication_email']);
@@ -152,8 +142,7 @@ class ParPartnershipFlowsContactSuggestionForm extends ParBaseForm {
 
     }
     else {
-      $cid = $this->getFlowNegotiator()->getFormKey('par_partnership_contact_suggestion');
-      $person_id = $this->getFlowDataHandler()->getDefaultValues('par_data_person_id', '', $cid);
+      $person_id = $this->getFlowDataHandler()->getDefaultValues('par_data_person_id');
       $par_data_person = ParDataPerson::load($person_id);
 
     }

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsContactSuggestionForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsContactSuggestionForm.php
@@ -39,6 +39,18 @@ class ParPartnershipFlowsContactSuggestionForm extends ParBaseForm {
    */
   public function buildForm(array $form, FormStateInterface $form_state, ParDataPartnership $par_data_partnership = NULL) {
 
+    // Get files from "contact_form" step.
+    // To use this form there must be a "form_data['contact_form']" key in the step configuration:
+    // 1:
+    //   route: example.route_name
+    //   form_id: form_id_where_person_was_added
+    //   form_data:
+    //     upload: par_partnership_advice_upload_edit
+    // 2:
+    //   route: example.route_name_2
+    //   form_id: example_form_id
+    //   form_data:
+    //     upload: form_id_where_person_was_added
     $cid = $this->getFlowNegotiator()->getFormKey('contact_form');
     $conditions = [
       'name' => [
@@ -112,7 +124,18 @@ class ParPartnershipFlowsContactSuggestionForm extends ParBaseForm {
     $par_data_partnership = $this->getFlowDataHandler()->getParameter('par_data_partnership');
     if ($this->getFlowDataHandler()->getDefaultValues('par_data_person_id') === 'new') {
 
-      // Create new person entity.
+      // Get files from "contact_form" step.
+      // To use this form there must be a "form_data['contact_form']" key in the step configuration:
+      // 1:
+      //   route: example.route_name
+      //   form_id: form_id_where_person_was_added
+      //   form_data:
+      //     upload: par_partnership_advice_upload_edit
+      // 2:
+      //   route: example.route_name_2
+      //   form_id: example_form_id
+      //   form_data:
+      //     upload: form_id_where_person_was_added
       $cid = $this->getFlowNegotiator()->getFormKey('contact_form');
       $par_data_person = ParDataPerson::create([
         'type' => 'person',

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsDetailsForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsDetailsForm.php
@@ -17,13 +17,6 @@ class ParPartnershipFlowsDetailsForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_partnership_details';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function titleCallback() {
     $par_data_partnership = $this->getFlowDataHandler()->getParameter('par_data_partnership');
     if ($par_data_partnership) {

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsEmployeeNoForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsEmployeeNoForm.php
@@ -18,13 +18,6 @@ class ParPartnershipFlowsEmployeeNoForm extends ParBaseForm {
   protected $pageTitle = 'Edit number of employees';
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_employee_number';
-  }
-
-  /**
    * Helper to get all the editable values when editing or
    * revisiting a previously edited page.
    *

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsInviteForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsInviteForm.php
@@ -25,13 +25,6 @@ class ParPartnershipFlowsInviteForm extends ParBaseForm {
   protected $pageTitle = 'Notify user of partnership invitation';
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_invite';
-  }
-
-  /**
    * Helper to get all the editable values when editing or
    * revisiting a previously edited page.
    *

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsLegalEntityForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsLegalEntityForm.php
@@ -19,13 +19,6 @@ class ParPartnershipFlowsLegalEntityForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_partnership_legal';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   protected $formItems = [
     'par_data_legal_entity:legal_entity' => [
       'registered_name' => 'registered_name',

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsMemberConfirmForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsMemberConfirmForm.php
@@ -70,13 +70,6 @@ class ParPartnershipFlowsMemberConfirmForm extends ParBaseForm {
     ],
   ];
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_member_upload_confirm';
-  }
-
   protected function getColumns() {
     return $this->columns;
   }

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsMemberUploadForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsMemberUploadForm.php
@@ -17,13 +17,6 @@ class ParPartnershipFlowsMemberUploadForm extends ParBaseForm {
   use ParPartnershipFlowsTrait;
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_member_upload';
-  }
-
-  /**
    * Helper to get all the editable values when editing or
    * revisiting a previously edited page.
    *

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsOrganisationSuggestionForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsOrganisationSuggestionForm.php
@@ -20,13 +20,6 @@ class ParPartnershipFlowsOrganisationSuggestionForm extends ParBaseForm {
   protected $pageTitle = 'Are you looking for one of these businesses?';
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_organisation_suggestion';
-  }
-
-  /**
    * Helper to get all the editable values when editing or
    * revisiting a previously edited page.
    *

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsPartnershipConfirmationForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsPartnershipConfirmationForm.php
@@ -21,13 +21,6 @@ class ParPartnershipFlowsPartnershipConfirmationForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_partnership_confirmation';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function titleCallback() {
     $par_data_partnership = $this->getFlowDataHandler()->getParameter('par_data_partnership');
     if ($par_data_partnership) {

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsSicCodeForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsSicCodeForm.php
@@ -15,13 +15,6 @@ class ParPartnershipFlowsSicCodeForm extends ParBaseForm {
   use ParPartnershipFlowsTrait;
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_sic_code';
-  }
-
-  /**
    * Helper to get all the editable values.
    *
    * Used for when editing or revisiting a previously edited page.

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsTradingForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsTradingForm.php
@@ -17,13 +17,6 @@ class ParPartnershipFlowsTradingForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_partnership_trading_name';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function titleCallback() {
     $trading_name_delta = $this->getFlowDataHandler()->getParameter('trading_name_delta');
 

--- a/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskApproveConfirmForm.php
+++ b/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskApproveConfirmForm.php
@@ -20,13 +20,6 @@ class ParRdHelpDeskApproveConfirmForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_rd_help_desk_confirm';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function titleCallback() {
     return 'Confirmation | Are you authorised to approve this partnership?';
   }

--- a/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskApproveForm.php
+++ b/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskApproveForm.php
@@ -24,13 +24,6 @@ class ParRdHelpDeskApproveForm extends ParBaseForm {
   }
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_rd_help_desk_approve';
-  }
-
-  /**
    * Helper to get all the editable values when editing or
    * revisiting a previously edited page.
    */

--- a/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskBulkInviteForm.php
+++ b/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskBulkInviteForm.php
@@ -23,13 +23,6 @@ class ParPartnershipFlowsInviteForm extends ParBaseForm {
   protected $flow = 'invite';
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_partnership_invite';
-  }
-
-  /**
    * Helper to get all the editable values when editing or
    * revisiting a previously edited page.
    *

--- a/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskRevokeConfirmForm.php
+++ b/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskRevokeConfirmForm.php
@@ -23,13 +23,6 @@ class ParRdHelpDeskRevokeConfirmForm extends ParBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'par_rd_help_desk_revoke_confirm';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function titleCallback() {
     return 'Confirmation | Revoke a partnership';
   }

--- a/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskRevokeForm.php
+++ b/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskRevokeForm.php
@@ -24,13 +24,6 @@ class ParRdHelpDeskRevokeForm extends ParBaseForm {
   }
 
   /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'par_rd_help_desk_revoke';
-  }
-
-  /**
    * Helper to get all the editable values when editing or
    * revisiting a previously edited page.
    */


### PR DESCRIPTION
The bug here was the fact that we'd moved from using the form id as a cache key for the form data to the route name.

We'd done this so that we could **avoid issues where the same form existed twice in a flow** (contact adding and editing). Previously the same cache was used for both forms, but now the data was only picked up from one of these, meaning that editing a contact worked, but not adding a contact.

The solution here is to use **individual form_ids** (unique for the flow) for the same form controller (contact_add and contact_edit), this has required a bigger shift towards having abstracted `form_data` keys that allow the current step to dictate which contact form it wants to get data form.

In this example the contact suggestion form is related to the contact add form but not the contact edit form, we can set this relationship using the `form_data` keys.

## Review notes:
In summary the [form id is now read from the `form_id` value in the flow step configuration](https://github.com/UKGovernmentBEIS/beis-primary-authority-register/pull/209/files#diff-77079c597435983accd9a5ca0200dcd2R171). This means that we can use the same form but a different form_id.

Most of the files in this PR are either [removing the hard coded `form_id`](https://github.com/UKGovernmentBEIS/beis-primary-authority-register/pull/209/files#diff-3a33efc7473622c704a4c32eea3b8838L39) or [changing the `form_id`s in the flow step configuration to be more unique](https://github.com/UKGovernmentBEIS/beis-primary-authority-register/pull/209/files#diff-20ca9e4c8b27cd0cd2bc3a529965fb85R66).