### PR TITLE
Remove PHP_EXTENSIONS directive from options.json

### DIFF
--- a/.bp-config/options.json
+++ b/.bp-config/options.json
@@ -1,6 +1,5 @@
 {
       "PHP_VERSION": "{PHP_71_LATEST}",
-      "PHP_EXTENSIONS": ["pdo", "bz2", "zlib", "curl", "mcrypt", "mbstring", "pgsql", "pdo_pgsql", "gd"],
       "PHP_MODULES": ["cli"],
       "WEBDIR": "web"
 }


### PR DESCRIPTION
This removes the deprecated PHP_EXTENSIONS directive from the PaaS options.json file.
