### PR TITLE
PAR-1071 Custom orginasation members for enforcement notifications

### DIFF
--- a/web/modules/custom/par_data/src/Entity/ParDataOrganisation.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataOrganisation.php
@@ -85,7 +85,7 @@ class ParDataOrganisation extends ParDataEntity {
   }
 
   /**
-   * Get the legal entites for this Organisation.
+   * Get the legal entities for this Organisation.
    */
   public function getLegalEntity($single = FALSE) {
     $legal_entities = $this->get('field_legal_entity')->referencedEntities();

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementApproveNoticeForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementApproveNoticeForm.php
@@ -95,6 +95,10 @@ class ParEnforcementApproveNoticeForm extends ParBaseForm {
       $form['legal_entity'] = $this->renderSection('Regarding', $par_data_enforcement_notice, ['legal_entity_name' => 'summary']);
     }
 
+    if (!$par_data_enforcement_notice->get('summary')->isEmpty()) {
+      $form['enforcement_summary'] = $this->renderSection('Summary of enforcement notice', $par_data_enforcement_notice, ['summary' => 'full']);
+    }
+
     // To account for enforcement notification data created before enforcement officer release.
     if (!empty($enforcing_officer)) {
       $form['enforcement_officer_name'] = $this->renderSection('Enforcing officer name', $enforcing_officer, ['first_name' => 'summary', 'last_name' => 'summary'], [], TRUE, TRUE);
@@ -118,7 +122,7 @@ class ParEnforcementApproveNoticeForm extends ParBaseForm {
         '#type' => 'fieldset',
          '#attributes' => ['class' => 'form-group'],
        ];
-      
+
       $form['actions'][$delta]['title'] = $this->renderSection('Title of action', $action, ['title' => 'title']);
       $form['actions'][$delta]['regulatory_function'] = $this->renderSection('Regulatory function', $action, ['field_regulatory_function' => 'title']);
       $form['actions'][$delta]['details'] = $this->renderSection('Details', $action, ['details' => 'full']);

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementApproveNoticeForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementApproveNoticeForm.php
@@ -95,10 +95,6 @@ class ParEnforcementApproveNoticeForm extends ParBaseForm {
       $form['legal_entity'] = $this->renderSection('Regarding', $par_data_enforcement_notice, ['legal_entity_name' => 'summary']);
     }
 
-    if (!$par_data_enforcement_notice->get('summary')->isEmpty()) {
-      $form['enforcement_summary'] = $this->renderSection('Summary of enforcement notice', $par_data_enforcement_notice, ['summary' => 'full']);
-    }
-
     // To account for enforcement notification data created before enforcement officer release.
     if (!empty($enforcing_officer)) {
       $form['enforcement_officer_name'] = $this->renderSection('Enforcing officer name', $enforcing_officer, ['first_name' => 'summary', 'last_name' => 'summary'], [], TRUE, TRUE);
@@ -122,7 +118,7 @@ class ParEnforcementApproveNoticeForm extends ParBaseForm {
         '#type' => 'fieldset',
          '#attributes' => ['class' => 'form-group'],
        ];
-
+      
       $form['actions'][$delta]['title'] = $this->renderSection('Title of action', $action, ['title' => 'title']);
       $form['actions'][$delta]['regulatory_function'] = $this->renderSection('Regulatory function', $action, ['field_regulatory_function' => 'title']);
       $form['actions'][$delta]['details'] = $this->renderSection('Details', $action, ['details' => 'full']);

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementEnforceOrganisationForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementEnforceOrganisationForm.php
@@ -59,7 +59,24 @@ class ParEnforcementEnforceOrganisationForm extends ParBaseForm {
           '#suffix' => '</strong><p>',
         ];
 
-        $this->getFlowNegotiator()->getFlow()->disableAction('next');
+        $form['select_alternative_organisation'] = [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Add organisation member'),
+          '#default_value' => $this->getFlowDataHandler()->getDefaultValues("select_alternative_organisation", FALSE),
+          '#required' => TRUE,
+        ];
+
+        $form['alternative_organisation_member'] = [
+          '#type' => 'textfield',
+          '#title' => $this->t('Enter the name of an organisation member'),
+          '#default_value' => $this->getFlowDataHandler()->getDefaultValues("alternative_organisation_member"),
+          '#states' => array(
+            'visible' => array(
+              ':input[name="select_alternative_organisation"]' => array('checked' => TRUE),
+            ),
+          ),
+          '#required' => TRUE,
+        ];
       }
       else {
         // Initialize pager and get current page.
@@ -69,7 +86,7 @@ class ParEnforcementEnforceOrganisationForm extends ParBaseForm {
         // Split the items up into chunks:
         $chunks = array_chunk($members, $number_of_items, TRUE);
 
-        // Add the items for our current page to the fieldset.
+        // Add the items for our current page to the field set.
         $page_options = [];
 
         foreach ($chunks[$current_page] as $delta => $item) {


### PR DESCRIPTION
This PR adds the functionality for entering a custom organisation member when there are no associated origination members on the partnership.

There are no wire-frames provided for this so we need to confirm with client the current designs.

This functionality requires some clarification around how the system should deal with a text field being stored instead of an organisation entity that has the complete data required for an organisation.

We will need additional ticket to update the flow including validation and storage as  currently when selecting a member to enforce this get stored as an entity ID on an entity ref field on the enforcment notice.

A possible solution could be that a new field is added to the notification entity the same as we currently do for legal entity free flow text field:


  $fields['legal_entity_name'] = BaseFieldDefinition::create('string')
      ->setLabel(t('Legal Entity Name'))
      ->setDescription(t('An optional free text field for entering a legal entity name.'))
      ->addConstraint('par_required')
      ->setRevisionable(TRUE)
      ->setSettings([
        'max_length' => 500,
        'text_processing' => 0,
      ])

We should also go through the rest of the raise and approve notification to test that they can be completed with text as the organisation member instead of an organisation entity.



![screen shot 2018-05-03 at 16 22 36](https://user-images.githubusercontent.com/772018/39586160-58bc6464-4eee-11e8-91a3-2127d0e49580.png)

![screen shot 2018-05-03 at 16 23 05](https://user-images.githubusercontent.com/772018/39586172-5f49e964-4eee-11e8-9120-f3f92064f11c.png)

