### PR TITLE
PAR-1454: Removed checks for master branch from deployment (IN PROGRESS)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,12 +273,7 @@ jobs:
           command: |
             DEPLOY_ENV="staging"
             printf "$DEPLOY_ENV\n"
-            if ! test $(git rev-parse master) = $(git rev-parse $CIRCLE_TAG^{commit}); then
-              echo "Tags can only be deployed from the master branch"
-              exit 1
-            else
-              ./devops/cf/push.local.sh -r -b /var/www/html/backups/${SANITISED_DATABASE} -d /tmp/workspace $DEPLOY_ENV
-            fi
+            ./devops/cf/push.local.sh -r -b /var/www/html/backups/${SANITISED_DATABASE} -d /tmp/workspace $DEPLOY_ENV
 
   deploy_prod:
     <<: *defaults
@@ -292,12 +287,7 @@ jobs:
           command: |
             DEPLOY_ENV="production"
             printf "$DEPLOY_ENV\n"
-            if ! test $(git rev-parse master) = $(git rev-parse $CIRCLE_TAG^{commit}); then
-              echo "Tags can only be deployed from the master branch"
-              exit 1
-            else
-              ./devops/cf/push.local.sh -u $GOVUK_CF_USER -p $GOVUK_CF_PWD -x -d /tmp/workspace -i 4 $DEPLOY_ENV
-            fi
+            ./devops/cf/push.local.sh -u $GOVUK_CF_USER -p $GOVUK_CF_PWD -x -d /tmp/workspace -i 4 $DEPLOY_ENV
 
   deploy_test:
     <<: *defaults


### PR DESCRIPTION
This can still only be run on tagged builds, it just means semver tags `v30.0.0` can now be run on any branch. This allows us to create 'release branches' so that we're not holding up other work for each release. But it does present a potential issue that semver tags can be added to non-protected branches.