### PR TITLE
PAR-1462: Updated advice views.

### DIFF
--- a/sync/views.view.advice_lists.yml
+++ b/sync/views.view.advice_lists.yml
@@ -914,6 +914,44 @@ display:
             group_items: {  }
           entity_type: par_data_advice
           plugin_id: par_data_status_filter
+        deleted:
+          id: deleted
+          table: par_advice_field_data
+          field: deleted
+          relationship: field_advice
+          group_type: group
+          admin_label: ''
+          operator: '!='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: par_data_advice
+          entity_field: deleted
+          plugin_id: boolean
       sorts:
         advice_status:
           id: advice_status


### PR DESCRIPTION
It appears that views will only do an access check on the primary listed entity and not the relationships. Because the advice views list the advice on a partnership it's therefore only checking the partnership for access.

This seems to be the easiest and best solution. We'll have to think about how to handle deleted entities better at a later date anyway.