### PR TITLE
PAR-1624: Improved the association of people with their user accounts

### DIFF
--- a/sync/user.role.par_authority.yml
+++ b/sync/user.role.par_authority.yml
@@ -125,3 +125,4 @@ permissions:
   - 'view unpublished par_data_premises entities'
   - 'view unpublished par_data_regulatory_function entities'
   - 'view unpublished par_data_sic_code entities'
+  - 'view user fields'

--- a/sync/user.role.par_helpdesk.yml
+++ b/sync/user.role.par_helpdesk.yml
@@ -203,3 +203,4 @@ permissions:
   - 'view unpublished par_data_premises entities'
   - 'view unpublished par_data_regulatory_function entities'
   - 'view unpublished par_data_sic_code entities'
+  - 'view user fields'

--- a/sync/user.role.par_organisation.yml
+++ b/sync/user.role.par_organisation.yml
@@ -103,3 +103,4 @@ permissions:
   - 'view unpublished par_data_premises entities'
   - 'view unpublished par_data_regulatory_function entities'
   - 'view unpublished par_data_sic_code entities'
+  - 'view user fields'

--- a/sync/views.view.par_people.yml
+++ b/sync/views.view.par_people.yml
@@ -95,6 +95,10 @@ display:
             email: email
             par_flow_link: par_flow_link
             par_flow_link_1: par_flow_link_1
+            authority_name: authority_name
+            organisation_name: organisation_name
+            trading_name_value: trading_name_value
+            par_person_email: par_person_email
           info:
             id:
               sortable: false
@@ -132,6 +136,34 @@ display:
               empty_column: false
               responsive: ''
             par_flow_link_1:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            authority_name:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            organisation_name:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            trading_name_value:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            par_person_email:
               sortable: false
               default_sort_order: asc
               align: ''
@@ -339,6 +371,56 @@ display:
           entity_type: par_data_person
           entity_field: last_name
           plugin_id: field
+        par_person_email:
+          id: par_person_email
+          table: par_people_field_data
+          field: par_person_email
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: E-mail
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          entity_type: par_data_person
+          plugin_id: par_person_account_email
         email:
           id: email
           table: par_people_field_data
@@ -347,7 +429,7 @@ display:
           group_type: group
           admin_label: ''
           label: E-mail
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -404,6 +486,73 @@ display:
           field_api_classes: false
           entity_type: par_data_person
           entity_field: email
+          plugin_id: field
+        access:
+          id: access
+          table: users_field_data
+          field: access
+          relationship: field_user_account
+          group_type: group
+          admin_label: ''
+          label: 'Last access'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: gds_date_format
+            custom_date_format: ''
+            timezone: ''
+          group_column: entity_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: access
           plugin_id: field
         par_flow_link:
           id: par_flow_link
@@ -708,7 +857,211 @@ display:
           entity_type: par_data_organisation
           entity_field: trading_name
           plugin_id: field
+        mail:
+          id: mail
+          table: users_field_data
+          field: mail
+          relationship: field_user_account
+          group_type: group
+          admin_label: ''
+          label: 'Account Email'
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: basic_string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: mail
+          plugin_id: field
       filters:
+        id_filter:
+          id: id_filter
+          table: par_people_field_data
+          field: id_filter
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: direct
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: par_data_person
+          plugin_id: par_member
+        combine_2:
+          id: combine_2
+          table: views
+          field: combine
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: word
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: combine_2_op
+            label: 'Search for name or email'
+            description: ''
+            use_operator: false
+            operator: combine_2_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: name_email_search
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              par_authority: '0'
+              par_enforcement: '0'
+              par_organisation: '0'
+              par_helpdesk: '0'
+              senior_administration_officer: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          fields:
+            first_name: first_name
+            last_name: last_name
+            email: email
+            mail: mail
+          plugin_id: combine
+        combine_1:
+          id: combine_1
+          table: views
+          field: combine
+          relationship: none
+          group_type: group
+          admin_label: 'Authority or Organisation'
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: combine_1_op
+            label: 'Authority or Organisation'
+            description: 'If you belong to more than one authority or organisation you can filter the list by it.'
+            use_operator: false
+            operator: combine_1_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: authority_organisation_filter
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              par_authority: '0'
+              par_enforcement: '0'
+              par_organisation: '0'
+              par_helpdesk: '0'
+              senior_administration_officer: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          fields:
+            authority_name: authority_name
+            organisation_name: organisation_name
+            trading_name_value: trading_name_value
+          plugin_id: combine
         deleted:
           id: deleted
           table: par_people_field_data
@@ -749,143 +1102,6 @@ display:
           entity_type: par_data_person
           entity_field: deleted
           plugin_id: boolean
-        id_filter:
-          id: id_filter
-          table: par_people_field_data
-          field: id_filter
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: direct
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: par_data_person
-          plugin_id: par_member
-        combine:
-          id: combine
-          table: views
-          field: combine
-          relationship: none
-          group_type: group
-          admin_label: User/Email
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: combine_op
-            label: 'First name / Last name / Email'
-            description: ''
-            use_operator: false
-            operator: combine_op
-            identifier: keywords
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              par_authority: '0'
-              par_enforcement: '0'
-              par_organisation: '0'
-              par_helpdesk: '0'
-            placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          fields:
-            first_name: first_name
-            last_name: last_name
-            email: email
-          plugin_id: combine
-        combine_1:
-          id: combine_1
-          table: views
-          field: combine
-          relationship: none
-          group_type: group
-          admin_label: 'Authority or Organisation'
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: combine_1_op
-            label: 'Authority or Organisation'
-            description: 'If you belong to more than one authority or organisation you can filter the list accordingly.'
-            use_operator: false
-            operator: combine_1_op
-            identifier: authority_organisation_filter
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              par_authority: '0'
-              par_enforcement: '0'
-              par_organisation: '0'
-              par_helpdesk: '0'
-            placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          fields:
-            authority_name: authority_name
-            organisation_name: organisation_name
-            trading_name_value: trading_name_value
-          plugin_id: combine
       sorts:
         last_name:
           id: last_name
@@ -900,6 +1116,20 @@ display:
             label: ''
           entity_type: par_data_person
           entity_field: last_name
+          plugin_id: standard
+        first_name:
+          id: first_name
+          table: par_people_field_data
+          field: first_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: par_data_person
+          entity_field: first_name
           plugin_id: standard
       title: People
       header:
@@ -939,6 +1169,15 @@ display:
           required: false
           entity_type: par_data_person
           plugin_id: entity_reverse
+        field_user_account:
+          id: field_user_account
+          table: par_data_person__field_user_account
+          field: field_user_account
+          relationship: none
+          group_type: group
+          admin_label: 'User Account'
+          required: false
+          plugin_id: standard
       arguments: {  }
       display_extenders: {  }
       filter_groups:

--- a/tests/features/user-management.feature
+++ b/tests/features/user-management.feature
@@ -130,7 +130,7 @@ Feature: User management
         Then the element "h1.heading-xlarge" contains the text "People"
         And the element ".user-management-list .table-scroll-wrapper" is visible
         Then the element ".user-management-list .table-scroll-wrapper thead .views-field-last-name" contains the text "Name"
-        And the element ".user-management-list .table-scroll-wrapper thead .views-field-email" contains the text "E-mail"
+        And the element ".user-management-list .table-scroll-wrapper thead .views-field-par-person-email" contains the text "E-mail"
         And the element ".user-management-list .table-scroll-wrapper thead .views-field-par-flow-link" contains the text "Actions"
 
         # Check the correct users can be managed.
@@ -147,7 +147,7 @@ Feature: User management
         When I click the link text "Manage your colleagues"
 
         Then the element "h1.heading-xlarge" contains the text "People"
-        When I add "par_user_management_multiple@example.com" to the inputfield "#edit-keywords"
+        When I add "par_user_management_multiple@example.com" to the inputfield "#edit-name-email-search"
         And I click on the button "#edit-submit-par-people"
         And I click the link text "Manage contact"
 
@@ -183,7 +183,7 @@ Feature: User management
 
         # Check the user details have been updated and the contact records merged.
         Then the element "h1.heading-xlarge" contains the text "People"
-        When I add "par_user_management_multiple@example.com" to the inputfield "#edit-keywords"
+        When I add "par_user_management_multiple@example.com" to the inputfield "#edit-name-email-search"
         And I click on the button "#edit-submit-par-people"
         And I click the link text "Manage contact"
 
@@ -197,7 +197,7 @@ Feature: User management
         When I click the link text "Manage your colleagues"
 
         Then the element "h1.heading-xlarge" contains the text "People"
-        When I add "par_user_management_officer@example.com" to the inputfield "#edit-keywords"
+        When I add "par_user_management_officer@example.com" to the inputfield "#edit-name-email-search"
         And I click on the button "#edit-submit-par-people"
         And I click the link text "Manage contact"
 
@@ -241,7 +241,7 @@ Feature: User management
         When I click the link text "Manage your colleagues"
 
         Then the element "h1.heading-xlarge" contains the text "People"
-        When I add "par_user_management_contact@example.com" to the inputfield "#edit-keywords"
+        When I add "par_user_management_contact@example.com" to the inputfield "#edit-name-email-search"
         And I click on the button "#edit-submit-par-people"
         And I click the link text "Manage contact"
 
@@ -272,7 +272,7 @@ Feature: User management
         When I click the link text "Manage people"
 
         Then the element "h1.heading-xlarge" contains the text "People"
-        When I add "par_authority_profile@example.com" to the inputfield "#edit-keywords"
+        When I add "par_authority_profile@example.com" to the inputfield "#edit-name-email-search"
         And I click on the button "#edit-submit-par-people"
         And I click the link text "Manage contact"
 
@@ -286,7 +286,7 @@ Feature: User management
         When I click the link text "Manage people"
 
         Then the element "h1.heading-xlarge" contains the text "People"
-        When I add "par_user_management_officer_2@example.com" to the inputfield "#edit-keywords"
+        When I add "par_user_management_officer_2@example.com" to the inputfield "#edit-name-email-search"
         And I click on the button "#edit-submit-par-people"
         And I click the link text "Manage contact"
 
@@ -306,7 +306,7 @@ Feature: User management
 
         Given I am logged in as "par_helpdesk@example.com"
         When I click the link text "Manage people"
-        When I add "par_user_management_officer_2@example.com" to the inputfield "#edit-keywords"
+        When I add "par_user_management_officer_2@example.com" to the inputfield "#edit-name-email-search"
         And I click on the button "#edit-submit-par-people"
         And I click the link text "Manage contact"
 

--- a/tests/features/user-management.feature
+++ b/tests/features/user-management.feature
@@ -187,7 +187,6 @@ Feature: User management
         And I click on the button "#edit-submit-par-people"
         And I click the link text "Manage contact"
 
-        Then the element "h1.heading-xlarge" contains the text "Dr Sally McHaels"
         And the element ".component-user-detail" contains the text "par_user_management_multiple@example.com"
 
     @user-management @ci

--- a/web/modules/custom/par_data/par_data.install
+++ b/web/modules/custom/par_data/par_data.install
@@ -10,6 +10,7 @@ use Drupal\par_data\Entity\ParDataPartnership;
 use Drupal\par_data\Entity\ParDataEntity;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\par_data\Entity\ParDataPersonInterface;
 
 /**
  * Implements hook_install().
@@ -1014,5 +1015,21 @@ function par_data_update_8043() {
     // Strip out the custom format embedded in the text value.
     $par_data_partnership->about_partnership->value = str_replace(', basic_html', '', $par_data_partnership->about_partnership->value);
     $par_data_partnership->save();
+  }
+}
+
+/**
+ * PAR-1624 Make all email addresses on par_data_person entities lowercase.
+ */
+function par_data_update_8045() {
+  $query = \Drupal::database()->query( "SELECT p.id as id FROM par_people_field_data AS p WHERE p.email!=LOWER(email);" );
+  $results = array_keys($query->fetchAllAssoc('id'));
+  if (!empty($results)) {
+    $entities = \Drupal::entityTypeManager()->getStorage('par_data_person')->loadMultiple($results);
+  }
+
+  foreach ($entities as $entity) {
+    // Re-saving the entity will automatically lowercase the email address.
+    $entity->save();
   }
 }

--- a/web/modules/custom/par_data/par_data.module
+++ b/web/modules/custom/par_data/par_data.module
@@ -13,6 +13,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\par_data\Entity\ParDataPartnership;
 use Drupal\par_data\Entity\ParDataPersonType;
 use Drupal\views\ViewExecutable;
+use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\par_data\Event\ParDataEvent;
 use Drupal\par_data\Entity\ParDataEntityInterface;
 
@@ -90,7 +91,7 @@ function par_data_entity_bundle_field_info_alter(&$fields, \Drupal\Core\Entity\E
  * @param \Drupal\views\ViewExecutable $view
  * @param $query
  */
-function par_data_views_query_alter(ViewExecutable $view, $query) {
+function par_data_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
 
   // PostgreSQL case insensitive query alter.
   foreach ($query->where as $group_key => $group) {
@@ -99,7 +100,7 @@ function par_data_views_query_alter(ViewExecutable $view, $query) {
       // Only apply to combined fields, Views stamps in queries are useful!
       if (preg_match('/:views_combine/', $condition['field'])) {
         // ILIKE is proprietary to PostgreSQL.
-        $query->where[$group_key]['conditions'][$key]['field'] = str_replace('LIKE', 'ILIKE', $condition['field']);
+        $query->where[$group_key]['conditions'][$key]['field'] = str_replace(' LIKE', ' ILIKE', $condition['field']);
       }
 
     }

--- a/web/modules/custom/par_data/src/Entity/ParDataPerson.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataPerson.php
@@ -77,7 +77,7 @@ use Drupal\user\UserInterface;
  *   field_ui_base_route = "entity.par_data_person_type.edit_form"
  * )
  */
-class ParDataPerson extends ParDataEntity {
+class ParDataPerson extends ParDataEntity implements ParDataPersonInterface {
 
   /**
    * {@inheritdoc}

--- a/web/modules/custom/par_data/src/Entity/ParDataPersonInterface.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataPersonInterface.php
@@ -9,7 +9,7 @@ use Drupal\user\UserInterface;
  *
  * @ingroup par_data
  */
-interface ParDataPersonInterface {
+interface ParDataPersonInterface extends ParDataEntityInterface {
 
   /**
    * Get the User account.

--- a/web/modules/custom/par_data/src/Plugin/views/field/ParPersonAccountEmail.php
+++ b/web/modules/custom/par_data/src/Plugin/views/field/ParPersonAccountEmail.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @file
+ * Definition of Drupal\d8views\Plugin\views\field\NodeTypeFlagger
+ */
+
+namespace Drupal\par_data\Plugin\views\field;
+
+use Drupal\par_data\Entity\ParDataPersonInterface;
+use Drupal\user\UserInterface;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+
+/**
+ * Field handler to get the email address associated with the person's user account.
+ *
+ * @ingroup views_field_handlers
+ *
+ * @ViewsField("par_person_account_email")
+ */
+class ParPersonEmail extends FieldPluginBase {
+
+  /**
+   * @{inheritdoc}
+   */
+  public function query() {
+    // Leave empty to avoid a query on this field.
+    parent::query();
+  }
+
+  /**
+   * @{inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    $entity = $this->getEntity($values);
+
+    if ($entity instanceof ParDataPersonInterface) {
+      // If the person has a user account with a different email address
+      // then this email address will be used.
+      $account = $entity->retrieveUserAccount();
+
+      return $account instanceof UserInterface ? $account->getEmail() : $entity->getEmail();
+    }
+  }
+}

--- a/web/modules/custom/par_data/src/Plugin/views/field/ParPersonAccountEmail.php
+++ b/web/modules/custom/par_data/src/Plugin/views/field/ParPersonAccountEmail.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\par_data\Plugin\views\field;
 
+use Drupal\par_data\Entity\ParDataEntityInterface;
 use Drupal\par_data\Entity\ParDataPersonInterface;
 use Drupal\user\UserInterface;
 use Drupal\views\Plugin\views\field\FieldPluginBase;
@@ -19,14 +20,20 @@ use Drupal\views\ResultRow;
  *
  * @ViewsField("par_person_account_email")
  */
-class ParPersonEmail extends FieldPluginBase {
+class ParPersonAccountEmail extends FieldPluginBase {
 
   /**
    * @{inheritdoc}
    */
   public function query() {
     // Leave empty to avoid a query on this field.
-    parent::query();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function usesGroupBy() {
+    return TRUE;
   }
 
   /**
@@ -40,7 +47,7 @@ class ParPersonEmail extends FieldPluginBase {
       // then this email address will be used.
       $account = $entity->retrieveUserAccount();
 
-      return $account instanceof UserInterface ? $account->getEmail() : $entity->getEmail();
+      return $account instanceof UserInterface ? strtolower($account->getEmail()) : strtolower($entity->getEmail());
     }
   }
 }

--- a/web/modules/custom/par_data/src/Views/ParDataViewsData.php
+++ b/web/modules/custom/par_data/src/Views/ParDataViewsData.php
@@ -137,6 +137,18 @@ class ParDataViewsData extends EntityViewsData implements EntityViewsDataInterfa
       ],
     ];
 
+    // Custom filter for grouping people by their user account emails.
+    if ($this->entityType->id() === 'par_data_person') {
+      $data[$this->entityType->getDataTable()]['par_person_email'] = [
+        'title' => t('Person Account Email'),
+        'field' => [
+          'title' => t('Person Account Email'),
+          'help' => t('Displays the email address for this persons account over the email address for the person.'),
+          'id' => 'par_person_account_email',
+        ],
+      ];
+    }
+
     return $data;
   }
 

--- a/web/modules/custom/par_data/tests/src/Kernel/Entity/EntityMergeTest.php
+++ b/web/modules/custom/par_data/tests/src/Kernel/Entity/EntityMergeTest.php
@@ -290,7 +290,7 @@ class EntityMergeTest extends ParDataTestBase {
     }
 
     // Check that the right number of matching people are found.
-    $people = $this->people[1]->getAllRelatedPeople();
+    $people = $this->people[1]->getSimilarPeople();
     $this->assertCount(6, $people, t('There are 6 people that share the same email address.'));
 
     // Merge the contact records.

--- a/web/modules/custom/par_data/tests/src/Kernel/Entity/EntityMergeTest.php
+++ b/web/modules/custom/par_data/tests/src/Kernel/Entity/EntityMergeTest.php
@@ -291,7 +291,7 @@ class EntityMergeTest extends ParDataTestBase {
 
     // Check that the right number of matching people are found.
     $people = $this->people[1]->getSimilarPeople();
-    $this->assertCount(6, $people, t('There are 6 people that share the same email address.'));
+    $this->assertCount(3, $people, t('There are 3 people that share the same email address and are not assigned to another user account.'));
 
     // Merge the contact records.
     // All authority contacts 2-6 should now be deleted and merged into contact 1.

--- a/web/modules/custom/par_roles/par_roles.module
+++ b/web/modules/custom/par_roles/par_roles.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Access\AccessResult;
 
 /**
  * Implements hook_help().
@@ -81,4 +82,22 @@ function par_roles_user_update($account) {
 
   $par_data_manager = \Drupal::service('par_data.manager');
   $par_data_manager->linkPeople($account);
+}
+
+/**
+ * Add a permission to allow other users to see user fields such as last login time.
+ *
+ * Added in PAR-1624 to allow last login time to be displayed in the /members view.
+ * https://www.drupal.org/project/drupal/issues/2799049
+ *
+ * @see \hook_entity_field_access()
+ *
+ * {@inheritDoc}
+ */
+function par_roles_entity_field_access($operation, \Drupal\Core\Field\FieldDefinitionInterface $field_definition, \Drupal\Core\Session\AccountInterface $account, \Drupal\Core\Field\FieldItemListInterface $items = NULL) {
+  if ($operation === 'view' && $field_definition->getTargetEntityTypeId() === 'user') {
+    return AccessResult::allowedIfHasPermission($account, 'view user fields');
+  }
+
+  return AccessResult::neutral();
 }

--- a/web/modules/custom/par_roles/par_roles.permissions.yml
+++ b/web/modules/custom/par_roles/par_roles.permissions.yml
@@ -12,3 +12,8 @@ invite authority members:
   title: 'Invite authority members to create accounts'
   description: 'Invite authority members that do not have user accounts to register with the system.'
   restrict access: TRUE
+# Permissions related to managing users.
+view user fields:
+  title: 'Allow other users to view user fields'
+  description: 'Allow user to view the fields belonging to other user accounts such as the last login time or email address.'
+  restrict access: TRUE

--- a/web/modules/features/par_person_merge_flows/src/Form/ParMergePeopleForm.php
+++ b/web/modules/features/par_person_merge_flows/src/Form/ParMergePeopleForm.php
@@ -28,7 +28,7 @@ class ParMergePeopleForm extends ParBaseForm {
 
   public function loadData() {
     $person = $this->getFlowDataHandler()->getParameter('par_data_person');
-    $people = $person->getAllRelatedPeople();
+    $people = $person->getSimilarPeople();
 
     if ($people) {
       $this->getFlowDataHandler()->setParameter('contacts', $people);

--- a/web/modules/features/par_person_merge_flows/src/ParFlowAccessTrait.php
+++ b/web/modules/features/par_person_merge_flows/src/ParFlowAccessTrait.php
@@ -31,7 +31,7 @@ trait ParFlowAccessTrait {
 
     }
 
-    $people = $par_data_person ? $par_data_person->getAllRelatedPeople() : NULL;
+    $people = $par_data_person ? $par_data_person->getSimilarPeople() : NULL;
     if (!$people || count($people) <= 1) {
       $this->accessResult = AccessResult::forbidden('There are not enough matching contact records to merge.');
     }

--- a/web/modules/features/par_profile_view_flows/src/Controller/ParProfileController.php
+++ b/web/modules/features/par_profile_view_flows/src/Controller/ParProfileController.php
@@ -78,7 +78,7 @@ class ParProfileController extends ParBaseController {
       }
     }
 
-    if ($par_data_person && $people = $par_data_person->getAllRelatedPeople()) {
+    if ($par_data_person && $people = $par_data_person->getSimilarPeople()) {
       $this->getFlowDataHandler()->setParameter('contacts', $people);
       $this->getFlowDataHandler()->setTempDataValue(ParFormBuilder::PAR_COMPONENT_PREFIX . 'contact_locations_detail', $people);
     }


### PR DESCRIPTION
* lower cased all people email addresses (resolves issues with aggregation in views)
* changed the way that similar people are looked up** see `ParDataPerson::getSimilarPeople()`
* grouped views by person email address and user account email address (allows for management of all cases)

** it is important that 'similar' people are looked up in the correct way, this avoids a mix and match of people and user accounts, the table below sums up the complexities:
Person Id | Person Email | User account email (linked on field_user_account)
------------ | ------------ | -------------
1 | 1@ | -
2 | 1@ | 1@
3 | 1@ | 2@
4 | 2@ | -
5 | 2@ | 1@
6 | 2@ | 2@

This is a perfectly acceptable situation, it arises from the need:
* to link all person email addresses with user accounts that have a matching email address
* but also to allow users to assign people with user accounts that don't match the person's email address (this happens occasionally where inboxes are shared within an organisation)

What this essentially looks like is that if I lookup `getSimilarPeople()` for each ID I get the following:
User Id | Email displayed / looked-up | Persoin IDs returned
------------ | ------------ | -------------
1 | 1@ | 1, 2, 5
2 | 1@ | 1, 2, 5
3 | 2@ | 3, 4, 6
4 | 2@ | 3, 4, 6
5 | 1@ | 1, 2, 5
6 | 2@ | 3, 4, 6

This is different to how it used to look (there's some confusing overlap here:
User Id | Email displayed / looked-up | Persoin IDs returned
------------ | ------------ | -------------
1 | 1@ | 1, 2, 3
2 | 1@ | 1, 2, 3, 5
3 | 1@ | 3, 4, 5, 6
4 | 2@ | 4, 5, 6
5 | 2@ | 1, 2, 3, 5
6 | 2@ | 3, 4, 5, 6

As such we need to develop an order of preference for the two conditions above.
* first we look at user accounts that have been 'assigned' (using `field_user_account`) to the person
* then we look at user accounts that have matching email addresses (this respects the ability to override the default)

When we lookup similar people we must also respect the order of preference for these relationships, as such we use the email address from the user account first followed by that of the person if there is no user account. We use this email address to then lookup all the people that are:

1. related to the user account
2. have the same email address as the user account and are not linked to a separate user account

Oh also the people listing now has the last access date on it which was requested:
![image](https://user-images.githubusercontent.com/334114/85526271-c421e680-b601-11ea-8167-7eb0ada2b634.png)
