### PR TITLE
PAR-1618: Updated plain text filtering.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -113,16 +113,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.143.0",
+            "version": "3.144.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "ce52251b25c83e225fc04043e6ee376465b6ae8f"
+                "reference": "3c6cc59be6a01f228fb53b2b5f43c1fd7d44a88c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/ce52251b25c83e225fc04043e6ee376465b6ae8f",
-                "reference": "ce52251b25c83e225fc04043e6ee376465b6ae8f",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/3c6cc59be6a01f228fb53b2b5f43c1fd7d44a88c",
+                "reference": "3c6cc59be6a01f228fb53b2b5f43c1fd7d44a88c",
                 "shasum": ""
             },
             "require": {
@@ -194,7 +194,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2020-06-24T19:09:03+00:00"
+            "time": "2020-06-30T18:14:11+00:00"
         },
         {
             "name": "bjeavons/zxcvbn-php",
@@ -4266,29 +4266,26 @@
         },
         {
             "name": "drupal/menu_link_attributes",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/menu_link_attributes.git",
-                "reference": "8.x-1.0"
+                "reference": "8.x-1.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/menu_link_attributes-8.x-1.0.zip",
-                "reference": "8.x-1.0",
-                "shasum": "6386cc2fcd7ae0d17d2a82d690866028b132055c"
+                "url": "https://ftp.drupal.org/files/projects/menu_link_attributes-8.x-1.1.zip",
+                "reference": "8.x-1.1",
+                "shasum": "d0207acb0cf253bea6204d1de99ea67b5aa1f5a2"
             },
             "require": {
-                "drupal/core": "*"
+                "drupal/core": "^8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
-                    "version": "8.x-1.0",
-                    "datestamp": "1507195827",
+                    "version": "8.x-1.1",
+                    "datestamp": "1593424626",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5740,23 +5737,24 @@
         },
         {
             "name": "drupal/xmlsitemap",
-            "version": "1.0.0-rc1",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/xmlsitemap.git",
-                "reference": "8.x-1.0-rc1"
+                "reference": "8.x-1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/xmlsitemap-8.x-1.0-rc1.zip",
-                "reference": "8.x-1.0-rc1",
-                "shasum": "9b88caa55f9a45b8c89a1284d2db739fbf0c830f"
+                "url": "https://ftp.drupal.org/files/projects/xmlsitemap-8.x-1.0.zip",
+                "reference": "8.x-1.0",
+                "shasum": "29395aa9eea8a58edefa3f9e0999d4d3a7f6b08f"
             },
             "require": {
-                "drupal/core": "~8.0",
+                "drupal/core": "^8.8 || ^9",
                 "ext-xmlwriter": "*"
             },
             "require-dev": {
+                "drupal/metatag": "^1.0",
                 "drupal/robotstxt": "^1.0"
             },
             "suggest": {
@@ -5764,15 +5762,12 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
-                    "version": "8.x-1.0-rc1",
-                    "datestamp": "1576705685",
+                    "version": "8.x-1.0",
+                    "datestamp": "1593451044",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "RC releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 },
                 "drush": {
@@ -5826,7 +5821,7 @@
             "description": "Creates XML sitemaps for the site",
             "homepage": "https://www.drupal.org/project/xmlsitemap",
             "support": {
-                "source": "http://cgit.drupalcode.org/xmlsitemap",
+                "source": "https://git.drupalcode.org/project/xmlsitemap",
                 "issues": "http://drupal.org/project/issues/xmlsitemap"
             }
         },
@@ -7161,20 +7156,20 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.5",
+            "version": "1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
+                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
-                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
+                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.1 || ^8.0"
             },
             "replace": {
                 "myclabs/deep-copy": "self.version"
@@ -7205,7 +7200,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2020-01-17T21:11:47+00:00"
+            "time": "2020-06-29T13:22:24+00:00"
         },
         {
             "name": "myclabs/php-enum",
@@ -8425,25 +8420,25 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b"
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
-                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-2.x": "2.x-dev"
                 }
             },
             "autoload": {
@@ -8470,7 +8465,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2020-04-27T09:25:28+00:00"
+            "time": "2020-06-27T09:03:43+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -8527,25 +8522,24 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "30441f2752e493c639526b215ed81d54f369d693"
+                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/30441f2752e493c639526b215ed81d54f369d693",
-                "reference": "30441f2752e493c639526b215ed81d54f369d693",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e878a14a65245fbe78f8080eba03b47c3b705651",
+                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2",
+                "php": "^7.2 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "^7.2",
-                "mockery/mockery": "~1"
+                "ext-tokenizer": "*"
             },
             "type": "library",
             "extra": {
@@ -8569,7 +8563,7 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2020-06-19T20:22:09+00:00"
+            "time": "2020-06-27T10:12:23+00:00"
         },
         {
             "name": "phpoffice/phpspreadsheet",
@@ -9395,20 +9389,20 @@
         },
         {
             "name": "psr/http-client",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-client.git",
-                "reference": "496a823ef742b632934724bf769560c2a5c7c44e"
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/496a823ef742b632934724bf769560c2a5c7c44e",
-                "reference": "496a823ef742b632934724bf769560c2a5c7c44e",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
+                "php": "^7.0 || ^8.0",
                 "psr/http-message": "^1.0"
             },
             "type": "library",
@@ -9440,7 +9434,7 @@
                 "psr",
                 "psr-18"
             ],
-            "time": "2018-10-30T23:29:13+00:00"
+            "time": "2020-06-29T06:28:15+00:00"
         },
         {
             "name": "psr/http-message",

--- a/sync/filter.format.plain_text.yml
+++ b/sync/filter.format.plain_text.yml
@@ -8,6 +8,12 @@ name: 'Plain text'
 format: plain_text
 weight: 10
 filters:
+  filter_html_escape:
+    id: filter_html_escape
+    provider: filter
+    status: true
+    weight: -10
+    settings: {  }
   filter_url:
     id: filter_url
     provider: filter

--- a/web/modules/custom/par_data/par_data.install
+++ b/web/modules/custom/par_data/par_data.install
@@ -1001,9 +1001,38 @@ function par_data_update_8042() {
 }
 
 /**
- * PAR-1624 Make all email addresses on par_data_person entities lowercase.
+ * PAR-1618 clean all par entity long text fields.
  */
 function par_data_update_8043() {
+  $par_data_manager = \Drupal::service('par_data.manager');
+
+  foreach ($par_data_manager->getParEntityTypes() as $entity_type_id => $entity_type_definition) {
+    foreach (\Drupal::service('entity_field.manager')->getFieldDefinitions($entity_type_id, '') as $field) {
+      if ($field->getType() == 'text_long') {
+
+        $field_name = $field->getName();
+        // Get all partnerships that have the format issue within the about business field.
+        $query = \Drupal::entityQuery($entity_type_id);
+        $query->condition($field_name . '__value', ', basic_html', 'CONTAINS');
+        $entity_ids = $query->execute();
+
+        // Load all entities to be updated.
+        $par_entities_to_update = \Drupal::entityTypeManager()->getStorage($entity_type_id)->loadMultiple($entity_ids);
+
+        foreach ($par_entities_to_update as $par_data_entity) {
+          // Strip out the custom format embedded in the text value.
+          $par_data_entity->$field_name->value = str_replace(', basic_html', '', $par_data_entity->$field_name->value);
+          $par_data_entity->save();
+        }
+      }
+    }
+  }
+}
+
+/**
+ * PAR-1624 Make all email addresses on par_data_person entities lowercase.
+ */
+function par_data_update_8044() {
   $query = \Drupal::database()->query( "SELECT p.id as id FROM par_people_field_data AS p WHERE p.email!=LOWER(email);" );
   $results = array_keys($query->fetchAllAssoc('id'));
   if (!empty($results)) {
@@ -1015,32 +1044,3 @@ function par_data_update_8043() {
     $entity->save();
   }
 }
-
-/**
- * PAR-1618 clean all par entity long text fields.
- */
-//function par_data_update_8044() {
-//  $par_data_manager = \Drupal::service('par_data.manager');
-//
-//  foreach ($par_data_manager->getParEntityTypes() as $entity_type_id => $entity_type_definition) {
-//    foreach (\Drupal::service('entity_field.manager')->getFieldDefinitions($entity_type_id, '') as $field) {
-//      if ($field->getType() == 'text_long') {
-//
-//        $field_name = $field->getName();
-//        // Get all partnerships that have the format issue within the about business field.
-//        $query = \Drupal::entityQuery($entity_type_id);
-//        $query->condition($field_name . '__value', ', basic_html', 'CONTAINS');
-//        $entity_ids = $query->execute();
-//
-//        // Load all entities to be updated.
-//        $par_entities_to_update = \Drupal::entityTypeManager()->getStorage($entity_type_id)->loadMultiple($entity_ids);
-//
-//        foreach ($par_entities_to_update as $par_data_entity) {
-//          // Strip out the custom format embedded in the text value.
-//          $par_data_entity->$field_name->value = str_replace(', basic_html', '', $par_data_entity->$field_name->value);
-//          $par_data_entity->save();
-//        }
-//      }
-//    }
-//  }
-//}

--- a/web/modules/custom/par_data/par_data.install
+++ b/web/modules/custom/par_data/par_data.install
@@ -1001,56 +1001,9 @@ function par_data_update_8042() {
 }
 
 /**
- * PAR-1618 clean the about partnership text.
- */
-function par_data_update_8043() {
-
-  // Get all partnerships that have the format issue within the about field.
-  $query = \Drupal::entityQuery('par_data_partnership');
-  $query->condition('about_partnership__value', ', basic_html', 'CONTAINS');
-  $entity_ids = $query->execute();
-  $partnerships_to_update = \Drupal::entityTypeManager()->getStorage('par_data_partnership')->loadMultiple($entity_ids);
-
-  foreach ($partnerships_to_update as $par_data_partnership) {
-    // Strip out the custom format embedded in the text value.
-    $par_data_partnership->about_partnership->value = str_replace(', basic_html', '', $par_data_partnership->about_partnership->value);
-    $par_data_partnership->save();
-  }
-}
-
-/**
- * PAR-1618 clean all par entity long text fields.
- */
-function par_data_update_8044() {
-  $par_data_manager = \Drupal::service('par_data.manager');
-
-  foreach ($par_data_manager->getParEntityTypes() as $entity_type_id => $entity_type_definition) {
-    foreach (\Drupal::service('entity_field.manager')->getFieldDefinitions($entity_type_id, '') as $field) {
-      if ($field->getType() == 'text_long') {
-
-        $field_name = $field->getName();
-        // Get all partnerships that have the format issue within the about business field.
-        $query = \Drupal::entityQuery($entity_type_id);
-        $query->condition($field_name . '__value', ', basic_html', 'CONTAINS');
-        $entity_ids = $query->execute();
-
-        // Load all entities to be updated.
-        $par_entities_to_update = \Drupal::entityTypeManager()->getStorage($entity_type_id)->loadMultiple($entity_ids);
-
-        foreach ($par_entities_to_update as $par_data_entity) {
-          // Strip out the custom format embedded in the text value.
-          $par_data_entity->$field_name->value = str_replace(', basic_html', '', $par_data_entity->$field_name->value);
-          $par_data_entity->save();
-        }
-      }
-    }
-  }
-}
-
-/**
  * PAR-1624 Make all email addresses on par_data_person entities lowercase.
  */
-function par_data_update_8045() {
+function par_data_update_8043() {
   $query = \Drupal::database()->query( "SELECT p.id as id FROM par_people_field_data AS p WHERE p.email!=LOWER(email);" );
   $results = array_keys($query->fetchAllAssoc('id'));
   if (!empty($results)) {
@@ -1062,3 +1015,32 @@ function par_data_update_8045() {
     $entity->save();
   }
 }
+
+/**
+ * PAR-1618 clean all par entity long text fields.
+ */
+//function par_data_update_8044() {
+//  $par_data_manager = \Drupal::service('par_data.manager');
+//
+//  foreach ($par_data_manager->getParEntityTypes() as $entity_type_id => $entity_type_definition) {
+//    foreach (\Drupal::service('entity_field.manager')->getFieldDefinitions($entity_type_id, '') as $field) {
+//      if ($field->getType() == 'text_long') {
+//
+//        $field_name = $field->getName();
+//        // Get all partnerships that have the format issue within the about business field.
+//        $query = \Drupal::entityQuery($entity_type_id);
+//        $query->condition($field_name . '__value', ', basic_html', 'CONTAINS');
+//        $entity_ids = $query->execute();
+//
+//        // Load all entities to be updated.
+//        $par_entities_to_update = \Drupal::entityTypeManager()->getStorage($entity_type_id)->loadMultiple($entity_ids);
+//
+//        foreach ($par_entities_to_update as $par_data_entity) {
+//          // Strip out the custom format embedded in the text value.
+//          $par_data_entity->$field_name->value = str_replace(', basic_html', '', $par_data_entity->$field_name->value);
+//          $par_data_entity->save();
+//        }
+//      }
+//    }
+//  }
+//}

--- a/web/modules/custom/par_data/par_data.install
+++ b/web/modules/custom/par_data/par_data.install
@@ -1001,9 +1001,25 @@ function par_data_update_8042() {
 }
 
 /**
- * PAR-1618 clean all par entity long text fields.
+ * PAR-1624 Make all email addresses on par_data_person entities lowercase.
  */
 function par_data_update_8043() {
+  $query = \Drupal::database()->query( "SELECT p.id as id FROM par_people_field_data AS p WHERE p.email!=LOWER(email);" );
+  $results = array_keys($query->fetchAllAssoc('id'));
+  if (!empty($results)) {
+    $entities = \Drupal::entityTypeManager()->getStorage('par_data_person')->loadMultiple($results);
+  }
+
+  foreach ($entities as $entity) {
+    // Re-saving the entity will automatically lowercase the email address.
+    $entity->save();
+  }
+}
+
+/**
+ * PAR-1618 clean all par entity long text fields.
+ */
+function par_data_update_8044() {
   $par_data_manager = \Drupal::service('par_data.manager');
 
   foreach ($par_data_manager->getParEntityTypes() as $entity_type_id => $entity_type_definition) {
@@ -1026,21 +1042,5 @@ function par_data_update_8043() {
         }
       }
     }
-  }
-}
-
-/**
- * PAR-1624 Make all email addresses on par_data_person entities lowercase.
- */
-function par_data_update_8044() {
-  $query = \Drupal::database()->query( "SELECT p.id as id FROM par_people_field_data AS p WHERE p.email!=LOWER(email);" );
-  $results = array_keys($query->fetchAllAssoc('id'));
-  if (!empty($results)) {
-    $entities = \Drupal::entityTypeManager()->getStorage('par_data_person')->loadMultiple($results);
-  }
-
-  foreach ($entities as $entity) {
-    // Re-saving the entity will automatically lowercase the email address.
-    $entity->save();
   }
 }

--- a/web/modules/custom/par_data/src/Entity/ParDataEntity.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataEntity.php
@@ -1027,18 +1027,27 @@ class ParDataEntity extends Trance implements ParDataEntityInterface {
    *   An array of value properties keyed by the field delta.
    */
   public function extractValues($field, $property = 'value') {
-    if (!$this->hasField($field)) {
+    if (!$this->hasField($field) || $this->get($field)->isEmpty()) {
       return;
     }
 
     $values = [];
-    foreach ($this->get($field)->getValue() as $key => $value) {
-      if (isset($value[$property])) {
-        $values[$key] = $value[$property];
+    foreach ($this->get($field) as $key => $field_item) {
+      if (!$field_item->isEmpty()) {
+        $values[$key] = $field_item->get($property)->getValue();
       }
     }
 
     return $values;
+  }
+
+  public function getPlain($field) {
+    if (!$this->hasField($field) || $this->get($field)->isEmpty()) {
+      return;
+    }
+
+    $value = $this->get($field)->first()->get('value')->getValue();
+    return check_markup($value, 'plain_text');
   }
 
   /**

--- a/web/modules/custom/par_data/src/ParDataStorage.php
+++ b/web/modules/custom/par_data/src/ParDataStorage.php
@@ -117,6 +117,18 @@ class ParDataStorage extends TranceStorage {
       }
     }
 
+    // Ensure that a format value is selected for all text_long field values.
+    // @SEE PAR-1618: Text formats not being correctly set or retrieved.
+    foreach ($entity->getFieldDefinitions() as $definition) {
+      if ($definition->getType() === 'text_long' && !$entity->get($definition->getName())->isEmpty()) {
+        foreach ($entity->get($definition->getName()) as $delta => $value) {
+          if ($value->get('format')->getValue() === NULL) {
+            $entity->get($definition->getName())->get($delta)->get('format')->setValue('plain_text');
+          }
+        }
+      }
+    }
+
     // Load the original entity if it already exists.
     if ($this->has($entity->id(), $entity) && !isset($entity->original)) {
       $entity->original = $this->loadUnchanged($entity->id());

--- a/web/modules/custom/par_flows/src/ParFlowDataHandler.php
+++ b/web/modules/custom/par_flows/src/ParFlowDataHandler.php
@@ -351,16 +351,11 @@ class ParFlowDataHandler implements ParFlowDataHandlerInterface {
   /**
    * {@inheritdoc}
    */
-  public function setFormPermValue($key, $value, ParFormPluginInterface $plugin = NULL, $process_text = FALSE, $format = 'basic_html') {
+  public function setFormPermValue($key, $value, ParFormPluginInterface $plugin = NULL) {
     $key = (array) $key;
     // Allow the plugin namespace to be used as a prefix if a plugin is passed in.
     if ($plugin && $plugin instanceof ParFormPluginInterface) {
       array_unshift($key, $plugin->getPluginNamespace());
-    }
-
-    // PAR-1618 Run all the enabled filters on a piece a text value.
-    if ($process_text === TRUE && is_string($value)) {
-      $value = check_markup($value, $format);
     }
 
     NestedArray::setValue($this->data, $key, $value, TRUE);

--- a/web/modules/custom/par_flows/src/ParFlowDataHandlerInterface.php
+++ b/web/modules/custom/par_flows/src/ParFlowDataHandlerInterface.php
@@ -200,11 +200,6 @@ interface ParFlowDataHandlerInterface {
    *   The value to store for this key. Can be any string, integer or object.
    * @param ParFormPluginInterface $plugin
    *   If passed the plugin namespace will be prepended to the key.
-   * @param string $format
-   *   (optional) The machine name of the filter format to be used to filter the
-   *   text. Defaults to the par html format.
-   * @param boolean $process_text
-   *   (optional) Weather to apply text filters to the form value..
    */
-  public function setFormPermValue($key, $value, ParFormPluginInterface $plugin = NULL, $process_text = FALSE, $format = 'basic_html');
+  public function setFormPermValue($key, $value, ParFormPluginInterface $plugin = NULL);
 }

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParAboutBusinessForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParAboutBusinessForm.php
@@ -29,8 +29,7 @@ class ParAboutBusinessForm extends ParFormPluginBase {
    */
   public function loadData($cardinality = 1) {
     if ($par_data_organisation = $this->getFlowDataHandler()->getParameter('par_data_organisation')) {
-      $information_display = $par_data_organisation->comments->value;
-      $this->getFlowDataHandler()->setFormPermValue('about_business', $information_display, NULL, TRUE);
+      $this->getFlowDataHandler()->setFormPermValue('about_business', $par_data_organisation->getPlain('comments'));
     }
 
     parent::loadData();

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParAboutPartnershipForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParAboutPartnershipForm.php
@@ -30,7 +30,7 @@ class ParAboutPartnershipForm extends ParFormPluginBase {
    */
   public function loadData($cardinality = 1) {
     if ($par_data_partnership = $this->getFlowDataHandler()->getParameter('par_data_organisation')) {
-      $this->getFlowDataHandler()->setFormPermValue('about_partnership', $par_data_partnership->get('about_partnership')->getString());
+      $this->getFlowDataHandler()->setFormPermValue('about_partnership', $par_data_partnership->getPlain('about_partnership'));
     }
 
     parent::loadData();
@@ -42,7 +42,7 @@ class ParAboutPartnershipForm extends ParFormPluginBase {
   public function getElements($form = [], $cardinality = 1) {
 
     $form['about_partnership'] = [
-      '#type' => 'textarea',
+      '#type' => 'text_format',
       '#title' => $this->t('Provide information about the partnership'),
       '#default_value' => $this->getDefaultValuesByKey('about_partnership', $cardinality),
       '#description' => '<p>Use this section to give a brief overview of the partnership. Include any information you feel may be useful to enforcing authorities.</p>',

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParContactDetailsFullForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParContactDetailsFullForm.php
@@ -50,7 +50,7 @@ class ParContactDetailsFullForm extends ParFormPluginBase {
       $this->setDefaultValuesByKey("work_phone", $cardinality, $par_data_person->get('work_phone')->getString());
       $this->setDefaultValuesByKey("mobile_phone", $cardinality, $par_data_person->get('mobile_phone')->getString());
       $this->setDefaultValuesByKey("email", $cardinality, $par_data_person->get('email')->getString());
-      $this->setDefaultValuesByKey("notes", $cardinality, $par_data_person->get('communication_notes')->getString());
+      $this->setDefaultValuesByKey("notes", $cardinality, $par_data_person->getPlain('communication_notes'));
 
       // Get preferred contact methods.
       $contact_options = [

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParContactPreferencesForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParContactPreferencesForm.php
@@ -28,7 +28,7 @@ class ParContactPreferencesForm extends ParFormPluginBase {
    */
   public function loadData($cardinality = 1) {
     if ($par_data_person = $this->getFlowDataHandler()->getParameter('par_data_person')) {
-      $this->setDefaultValuesByKey("notes", $cardinality, $par_data_person->get('communication_notes')->getString());
+      $this->setDefaultValuesByKey("notes", $cardinality, $par_data_person->getPlain('communication_notes'));
 
       // Get preferred contact methods.
       $contact_options = [

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParDeviationRequestForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParDeviationRequestForm.php
@@ -32,7 +32,7 @@ class ParDeviationRequestForm extends ParFormPluginBase {
    */
   public function loadData($cardinality = 1) {
     if ($par_data_deviation_request = $this->getFlowDataHandler()->getParameter('par_data_deviation_request')) {
-      $this->getFlowDataHandler()->setFormPermValue('notes', $par_data_deviation_request->get('notes')->getString());
+      $this->getFlowDataHandler()->setFormPermValue('notes', $par_data_deviation_request->getPlain('notes'));
     }
 
     parent::loadData();

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParEnquiryForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParEnquiryForm.php
@@ -29,7 +29,7 @@ class ParEnquiryForm extends ParFormPluginBase {
    */
   public function loadData($cardinality = 1) {
     if ($par_data_general_enquiry = $this->getFlowDataHandler()->getParameter('par_data_general_enquiry')) {
-      $this->getFlowDataHandler()->setFormPermValue('notes', $par_data_general_enquiry->get('notes')->getString());
+      $this->getFlowDataHandler()->setFormPermValue('notes', $par_data_general_enquiry->getPlain('notes'));
     }
 
     parent::loadData();

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParInspectionFeedbackForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParInspectionFeedbackForm.php
@@ -29,7 +29,7 @@ class ParInspectionFeedbackForm extends ParFormPluginBase {
    */
   public function loadData($cardinality = 1) {
     if ($par_data_inspection_feedback = $this->getFlowDataHandler()->getParameter('par_data_inspection_feedback')) {
-      $this->getFlowDataHandler()->setFormPermValue('notes', $par_data_inspection_feedback->get('notes')->getString());
+      $this->getFlowDataHandler()->setFormPermValue('notes', $par_data_inspection_feedback->getPlain('notes'));
     }
 
     parent::loadData();

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParInspectionPlanForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParInspectionPlanForm.php
@@ -31,7 +31,7 @@ class ParInspectionPlanForm extends ParFormPluginBase {
    */
   public function loadData($cardinality = 1) {
     if ($par_data_inspection_feedback = $this->getFlowDataHandler()->getParameter('par_data_inspection_feedback')) {
-      $this->getFlowDataHandler()->setFormPermValue('notes', $par_data_inspection_feedback->get('notes')->getString());
+      $this->getFlowDataHandler()->setFormPermValue('notes', $par_data_inspection_feedback->getPlain('notes'));
     }
 
     parent::loadData();

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParMessageForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParMessageForm.php
@@ -20,7 +20,8 @@ class ParMessageForm extends ParFormPluginBase {
    */
   public function loadData($cardinality = 1) {
     if ($message = $this->getFlowDataHandler()->getParameter('comment')) {
-      $this->getFlowDataHandler()->setFormPermValue('message', $message->get('comment_body')->getString());
+      $message_value = !$message->get('comment_body')->isEmpty() ? $message->get('comment_body')->first()->get('value')->getValue() : '';
+      $this->getFlowDataHandler()->setFormPermValue('message', $message_value);
       $this->getFlowDataHandler()->setFormPermValue('files', $message->get('field_supporting_document')->getString());
     }
 

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAboutBusinessForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAboutBusinessForm.php
@@ -27,12 +27,8 @@ class ParPartnershipFlowsAboutBusinessForm extends ParBaseForm {
    *   The Partnership being retrieved.
    */
   public function retrieveEditableValues(ParDataPartnership $par_data_partnership = NULL) {
-    if ($par_data_partnership) {
-      // If we want to use values already saved we have to tell
-      // the form about them.
-      $par_data_organisation = current($par_data_partnership->getOrganisation());
-      $information_display = $par_data_organisation->comments->value;
-      $this->getFlowDataHandler()->setFormPermValue('about_business', $information_display);
+    if ($par_data_partnership && $par_data_organisation = $par_data_partnership->getOrganisation(TRUE)) {
+      $this->getFlowDataHandler()->setFormPermValue('about_business', $par_data_organisation->getPlain('comments'));
     }
   }
 
@@ -77,7 +73,10 @@ class ParPartnershipFlowsAboutBusinessForm extends ParBaseForm {
     // Save the value for the about_partnership field.
     $partnership = $this->getFlowDataHandler()->getParameter('par_data_partnership');
     $par_data_organisation = current($partnership->getOrganisation());
-    $par_data_organisation->set('comments', $this->getFlowDataHandler()->getTempDataValue('about_business'));
+    $par_data_organisation->get('comments')->setValue([
+      'value' => $this->getFlowDataHandler()->getTempDataValue('about_business'),
+      'format' => 'plain_text',
+    ]);
     if ($par_data_organisation->save()) {
       $this->getFlowDataHandler()->deleteStore();
     }

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAboutForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAboutForm.php
@@ -46,8 +46,7 @@ class ParPartnershipFlowsAboutForm extends ParBaseForm {
    */
   public function retrieveEditableValues(ParDataPartnership $par_data_partnership = NULL) {
     if ($par_data_partnership) {
-      $information_display = $par_data_partnership->about_partnership->value;
-      $this->getFlowDataHandler()->setFormPermValue('about_partnership', $information_display, NULL, TRUE);
+      $this->getFlowDataHandler()->setFormPermValue('about_partnership', $par_data_partnership->getPlain('about_partnership'));
     }
   }
 
@@ -81,7 +80,10 @@ class ParPartnershipFlowsAboutForm extends ParBaseForm {
 
     if ($par_data_partnership) {
       // Save the value for the about_partnership field.
-      $par_data_partnership->set('about_partnership', $this->getFlowDataHandler()->getTempDataValue('about_partnership'));
+      $par_data_partnership->get('about_partnership')->setValue([
+        'value' => $this->getFlowDataHandler()->getTempDataValue('about_partnership'),
+        'format' => 'plain_text',
+      ]);
       if ($par_data_partnership->save()) {
         $this->getFlowDataHandler()->deleteStore();
       }

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAdviceForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsAdviceForm.php
@@ -77,7 +77,7 @@ class ParPartnershipFlowsAdviceForm extends ParBaseForm {
       }
 
       // Advice summary.
-      $notes = $par_data_advice->get('notes')->getString();
+      $notes = $par_data_advice->getPlain('notes');
       if (isset($notes)) {
         $this->getFlowDataHandler()->setFormPermValue('notes', $notes);
       }

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsInspectionPlanForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsInspectionPlanForm.php
@@ -62,7 +62,7 @@ class ParPartnershipFlowsInspectionPlanForm extends ParBaseForm {
       }
 
       // Inspection plan summary.
-      $notes = $par_data_inspection_plan->get('summary')->getString();
+      $notes = $par_data_inspection_plan->getPlain('summary');
       if (isset($notes)) {
         $this->getFlowDataHandler()->setFormPermValue('summary', $notes);
       }


### PR DESCRIPTION
There are three things that need to happen simultaneously to make sure we don't get filter inputs in the text area:

1. Save the format `plain_text` every time.
2. Don't call `getString()` to but `get('value')->getValue()` and extract the raw value instead of the combined value.
3. Sanitise all existing cases where the filter input is already in the field value as per the hook_8044

If we don't do 1) then all the current values that have been saved _without_ a format will 'assume' a format when next that page is edited in the CKeditor, and usually they'll assume the wrong format (hence the missing formatting).

If we don't do 2) then all the current values that have been saved _with_ a format will output string+format when next they are edited in any of the journeys... and they will therefore be saved with this format appended to the value in the value field.