### PR TITLE
PAR-1632: Updated permissions for managing partnership contacts.

### DIFF
--- a/web/modules/features/par_member_add_flows/src/ParFlowAccessTrait.php
+++ b/web/modules/features/par_member_add_flows/src/ParFlowAccessTrait.php
@@ -6,6 +6,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\par_data\Entity\ParDataPartnership;
 use Drupal\par_flows\ParFlowException;
+use Drupal\user\Entity\User;
 use Symfony\Component\Routing\Route;
 use Drupal\Core\Routing\RouteMatchInterface;
 
@@ -27,15 +28,21 @@ trait ParFlowAccessTrait {
 
     }
 
+    $user = $account->isAuthenticated() ? User::load($account->id()) : NULL;
+
     // If the partnership isn't a coordinated one then don't allow update.
     if (!$par_data_partnership->isCoordinated()) {
       $this->accessResult = AccessResult::forbidden('This is not a coordinated partnership.');
     }
 
-    $locked = FALSE;
+    // Check the user has permission to manage the current organisation.
+    if (!$account->hasPermission('bypass par_data membership')
+      && !$this->getParDataManager()->isMember($par_data_partnership->getOrganisation(TRUE), $user)) {
+      $this->accessResult = AccessResult::forbidden('User does not have permissions to remove authority contacts from this partnership.');
+    }
 
     // If the member upload is in progress the member list cannot be modified.
-    if ($locked) {
+    if ($par_data_partnership->isMembershipLocked()) {
       $this->accessResult = AccessResult::forbidden('This member list is locked because an upload is in progress.');
     }
 

--- a/web/modules/features/par_partnership_contact_add_flows/src/Form/ParReviewForm.php
+++ b/web/modules/features/par_partnership_contact_add_flows/src/Form/ParReviewForm.php
@@ -176,8 +176,6 @@ class ParReviewForm extends ParBaseForm {
   }
 
   public function createEntities() {
-    $current_user = $this->getCurrentUser();
-
     // Get the cache IDs for the various forms that needs needs to be extracted from.
     $contact_details_cid = $this->getFlowNegotiator()->getFormKey('par_add_contact');
     $contact_dedupe_cid = $this->getFlowNegotiator()->getFormKey('dedupe_contact');
@@ -204,7 +202,7 @@ class ParReviewForm extends ParBaseForm {
         'work_phone' => $this->getFlowDataHandler()->getTempDataValue('work_phone', $contact_details_cid),
         'mobile_phone' => $this->getFlowDataHandler()->getTempDataValue('mobile_phone', $contact_details_cid),
       ]);
-      $par_data_person->updateEmail($this->getFlowDataHandler()->getTempDataValue('email', $contact_details_cid), $current_user);
+      $par_data_person->updateEmail($this->getFlowDataHandler()->getTempDataValue('email', $contact_details_cid), $account);
 
       if ($communication_notes = $this->getFlowDataHandler()->getTempDataValue('notes', $contact_details_cid)) {
         $par_data_person->set('communication_notes', $communication_notes);

--- a/web/modules/features/par_partnership_contact_add_flows/src/ParFlowAccessTrait.php
+++ b/web/modules/features/par_partnership_contact_add_flows/src/ParFlowAccessTrait.php
@@ -50,7 +50,7 @@ trait ParFlowAccessTrait {
           $this->accessResult = AccessResult::forbidden('User does not have permissions to update organisation contacts.');
         }
 
-        // Check the user has permission to manage the current authority.
+        // Check the user has permission to manage the current organisation.
         if (!$account->hasPermission('bypass par_data membership')
           && !$this->getParDataManager()->isMember($par_data_partnership->getOrganisation(TRUE), $user)) {
           $this->accessResult = AccessResult::forbidden('User does not have permissions to remove authority contacts from this partnership.');

--- a/web/modules/features/par_partnership_contact_add_flows/src/ParFlowAccessTrait.php
+++ b/web/modules/features/par_partnership_contact_add_flows/src/ParFlowAccessTrait.php
@@ -29,10 +29,18 @@ trait ParFlowAccessTrait {
 
     }
 
+    $user = $account->isAuthenticated() ? User::load($account->id()) : NULL;
+
     switch ($type) {
       case 'authority':
         if (!$account->hasPermission('add partnership authority contact')) {
           $this->accessResult = AccessResult::forbidden('User does not have permissions to update authority contacts.');
+        }
+
+        // Check the user has permission to manage the current authority.
+        if (!$account->hasPermission('bypass par_data membership')
+          && !$this->getParDataManager()->isMember($par_data_partnership->getAuthority(TRUE), $user)) {
+          $this->accessResult = AccessResult::forbidden('User does not have permissions to remove authority contacts from this partnership.');
         }
 
         break;
@@ -40,6 +48,12 @@ trait ParFlowAccessTrait {
       case 'organisation':
         if (!$account->hasPermission('add partnership organisation contact')) {
           $this->accessResult = AccessResult::forbidden('User does not have permissions to update organisation contacts.');
+        }
+
+        // Check the user has permission to manage the current authority.
+        if (!$account->hasPermission('bypass par_data membership')
+          && !$this->getParDataManager()->isMember($par_data_partnership->getOrganisation(TRUE), $user)) {
+          $this->accessResult = AccessResult::forbidden('User does not have permissions to remove authority contacts from this partnership.');
         }
 
         break;

--- a/web/modules/features/par_partnership_contact_remove_flows/src/ParFlowAccessTrait.php
+++ b/web/modules/features/par_partnership_contact_remove_flows/src/ParFlowAccessTrait.php
@@ -52,7 +52,7 @@ trait ParFlowAccessTrait {
         }
         $people = $par_data_partnership->getOrganisationPeople();
 
-        // Check the user has permission to manage the current authority.
+        // Check the user has permission to manage the current organisation.
         if (!$account->hasPermission('bypass par_data membership')
           && !$this->getParDataManager()->isMember($par_data_partnership->getOrganisation(TRUE), $user)) {
           $this->accessResult = AccessResult::forbidden('User does not have permissions to remove organisation contacts from this partnership.');

--- a/web/modules/features/par_partnership_contact_remove_flows/src/ParFlowAccessTrait.php
+++ b/web/modules/features/par_partnership_contact_remove_flows/src/ParFlowAccessTrait.php
@@ -29,12 +29,20 @@ trait ParFlowAccessTrait {
 
     }
 
+    $user = $account->isAuthenticated() ? User::load($account->id()) : NULL;
+
     switch ($type) {
       case 'authority':
         if (!$account->hasPermission('remove partnership authority contact')) {
           $this->accessResult = AccessResult::forbidden('User does not have permissions to remove authority contacts.');
         }
         $people = $par_data_partnership->getAuthorityPeople();
+
+        // Check the user has permission to manage the current authority.
+        if (!$account->hasPermission('bypass par_data membership')
+          && !$this->getParDataManager()->isMember($par_data_partnership->getAuthority(TRUE), $user)) {
+          $this->accessResult = AccessResult::forbidden('User does not have permissions to remove authority contacts from this partnership.');
+        }
 
         break;
 
@@ -43,6 +51,12 @@ trait ParFlowAccessTrait {
           $this->accessResult = AccessResult::forbidden('User does not have permissions to remove organisation contacts.');
         }
         $people = $par_data_partnership->getOrganisationPeople();
+
+        // Check the user has permission to manage the current authority.
+        if (!$account->hasPermission('bypass par_data membership')
+          && !$this->getParDataManager()->isMember($par_data_partnership->getOrganisation(TRUE), $user)) {
+          $this->accessResult = AccessResult::forbidden('User does not have permissions to remove organisation contacts from this partnership.');
+        }
 
         break;
 

--- a/web/modules/features/par_partnership_contact_update_flows/src/ParFlowAccessTrait.php
+++ b/web/modules/features/par_partnership_contact_update_flows/src/ParFlowAccessTrait.php
@@ -50,7 +50,7 @@ trait ParFlowAccessTrait {
           $this->accessResult = AccessResult::forbidden('User does not have permissions to update organisation contacts.');
         }
 
-        // Check the user has permission to manage the current authority.
+        // Check the user has permission to manage the current organisation.
         if (!$account->hasPermission('bypass par_data membership')
           && !$this->getParDataManager()->isMember($par_data_partnership->getOrganisation(TRUE), $user)) {
           $this->accessResult = AccessResult::forbidden('User does not have permissions to remove authority contacts from this partnership.');

--- a/web/modules/features/par_partnership_contact_update_flows/src/ParFlowAccessTrait.php
+++ b/web/modules/features/par_partnership_contact_update_flows/src/ParFlowAccessTrait.php
@@ -29,6 +29,7 @@ trait ParFlowAccessTrait {
     } catch (ParFlowException $e) {
 
     }
+    $user = $account->isAuthenticated() ? User::load($account->id()) : NULL;
 
     switch ($type) {
       case 'authority':
@@ -36,11 +37,23 @@ trait ParFlowAccessTrait {
           $this->accessResult = AccessResult::forbidden('User does not have permissions to update authority contacts.');
         }
 
+        // Check the user has permission to manage the current authority.
+        if (!$account->hasPermission('bypass par_data membership')
+          && !$this->getParDataManager()->isMember($par_data_partnership->getAuthority(TRUE), $user)) {
+          $this->accessResult = AccessResult::forbidden('User does not have permissions to remove authority contacts from this partnership.');
+        }
+
         break;
 
       case 'organisation':
         if (!$account->hasPermission('update partnership organisation contact')) {
           $this->accessResult = AccessResult::forbidden('User does not have permissions to update organisation contacts.');
+        }
+
+        // Check the user has permission to manage the current authority.
+        if (!$account->hasPermission('bypass par_data membership')
+          && !$this->getParDataManager()->isMember($par_data_partnership->getOrganisation(TRUE), $user)) {
+          $this->accessResult = AccessResult::forbidden('User does not have permissions to remove authority contacts from this partnership.');
         }
 
         break;


### PR DESCRIPTION
To reference one instance where this check is already being used - https://github.com/UKGovernmentBEIS/beis-primary-authority-register/blob/master/web/modules/features/par_partnership_flows/src/ParPartnershipFlowAccessTrait.php#L38

We just forgot to apply this to all the spin-off partnership management journeys.