### PR TITLE
PAR-1653  

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,12 +28,12 @@ references:
   restore_code: &restore_code
     restore_cache:
       keys:
-        - v8-repo-{{ .Branch }}-{{ .Revision }}
+        - v9-repo-{{ .Branch }}-{{ .Revision }}
 
   restore_dependencies: &restore_dependencies
     restore_cache:
       keys:
-        - v8-dependencies-{{ checksum "composer.lock" }}-{{ checksum "package-lock.json" }}
+        - v9-dependencies-{{ checksum "composer.lock" }}-{{ checksum "package-lock.json" }}
 
   restore_scaffold: &restore_scaffold
     run:
@@ -98,7 +98,7 @@ jobs:
           name: "Unpacking database"
           command: cd backups && tar --no-same-owner -zxvf ${SANITISED_DATABASE}-latest.tar.gz
       - save_cache:
-          key: v8-repo-{{ .Branch }}-{{ .Revision }}
+          key: v9-repo-{{ .Branch }}-{{ .Revision }}
           paths:
             - .
 
@@ -117,7 +117,7 @@ jobs:
             npm run gulp
             cd ./tests && rm -rf node_modules && npm install
       - save_cache:
-          key: v8-dependencies-{{ checksum "composer.lock" }}-{{ checksum "package-lock.json" }}
+          key: v9-dependencies-{{ checksum "composer.lock" }}-{{ checksum "package-lock.json" }}
           paths:
             - ./vendor
             - ./web/core

--- a/web/themes/custom/par_theme/par_theme.libraries.yml
+++ b/web/themes/custom/par_theme/par_theme.libraries.yml
@@ -1,5 +1,5 @@
 par-kour:
-  version: 1.1
+  version: 2.1
   js:
     javascript/par.js: {}
   css:
@@ -13,7 +13,7 @@ par-kour:
     - par_theme/par-vendor
 
 par-conditionals:
-  version: 1.0
+  version: 2.0
   js:
     javascript/ie.js: { browsers: { IE: 'lt IE 9', '!IE': false }}
   css:
@@ -24,7 +24,7 @@ par-conditionals:
       assets/fonts/fonts-ie8.css: { browsers: { IE: 'lt IE 9', '!IE': false } }
 
 par-vendor:
-  version: 1.0
+  version: 2.0
   js:
     javascript/vendor/console.log-wrapper/consolelog.min.js: {}
     javascript/vendor/console.log-wrapper/consolelog.detailprint.min.js: {}

--- a/web/themes/custom/par_theme/par_theme.libraries.yml
+++ b/web/themes/custom/par_theme/par_theme.libraries.yml
@@ -1,5 +1,5 @@
 par-kour:
-  version: 2.1
+  version: 1.0
   js:
     javascript/par.js: {}
   css:
@@ -13,7 +13,7 @@ par-kour:
     - par_theme/par-vendor
 
 par-conditionals:
-  version: 2.0
+  version: 1.0
   js:
     javascript/ie.js: { browsers: { IE: 'lt IE 9', '!IE': false }}
   css:
@@ -24,7 +24,7 @@ par-conditionals:
       assets/fonts/fonts-ie8.css: { browsers: { IE: 'lt IE 9', '!IE': false } }
 
 par-vendor:
-  version: 2.0
+  version: 1.0
   js:
     javascript/vendor/console.log-wrapper/consolelog.min.js: {}
     javascript/vendor/console.log-wrapper/consolelog.detailprint.min.js: {}

--- a/web/themes/custom/par_theme/par_theme.libraries.yml
+++ b/web/themes/custom/par_theme/par_theme.libraries.yml
@@ -1,5 +1,5 @@
 par-kour:
-  version: 1.0
+  version: 1.1
   js:
     javascript/par.js: {}
   css:

--- a/web/themes/custom/par_theme/sass/par.scss
+++ b/web/themes/custom/par_theme/sass/par.scss
@@ -277,6 +277,11 @@ div.pagerer-container {
   margin-top: 2em;
 }
 
+/* Flow links */
+
+a.flow-link {
+    display: table;
+}
 
 /* Reset */
 fieldset, legend {

--- a/web/themes/custom/par_theme/sass/par.scss
+++ b/web/themes/custom/par_theme/sass/par.scss
@@ -277,11 +277,6 @@ div.pagerer-container {
   margin-top: 2em;
 }
 
-/* Flow links */
-
-a.flow-link {
-    display: block;
-}
 
 /* Reset */
 fieldset, legend {


### PR DESCRIPTION
Not sure if we need to explicitly set display block styling for par flow links?  

removing this styling does not seem to change the fact that the elements are still displaying as a block element 
(like <p>) with each flow link displays on a new line.

Removing this prevents the element highlighting the whole length which looks quite bad.

display: table can also be used to put the element on a new line but with out the whole length issue.. 




![Screen Shot 2020-07-16 at 19 42 18](https://user-images.githubusercontent.com/772018/87710755-163bcf00-c79e-11ea-8a39-c826ecc12293.png)
![Screen Shot 2020-07-16 at 19 42 59](https://user-images.githubusercontent.com/772018/87710762-18059280-c79e-11ea-8cb6-3c0a6151060a.png)

Updated SCSS:

![Screen Shot 2020-07-16 at 19 49 16](https://user-images.githubusercontent.com/772018/87710786-25bb1800-c79e-11ea-9065-f839edbac84d.png)
![Screen Shot 2020-07-16 at 19 49 36](https://user-images.githubusercontent.com/772018/87710792-28b60880-c79e-11ea-89e2-2a2bbce3c6b9.png)




