### PR TITLE
PAR-1633 adding  phone number format validation

### DIFF
--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParContactDetailsBasicForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParContactDetailsBasicForm.php
@@ -63,6 +63,9 @@ class ParContactDetailsBasicForm extends ParFormPluginBase {
       '#type' => 'tel',
       '#title' => $this->t('Enter the work phone number'),
       '#default_value' => $this->getDefaultValuesByKey('work_phone', $cardinality),
+      '#attributes' => [
+        'pattern' => "(\+?\(?\d{2,4}\)?[\d\s-]{3,})",
+      ],
     ];
 
     return $form;

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParContactDetailsForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParContactDetailsForm.php
@@ -85,12 +85,18 @@ class ParContactDetailsForm extends ParFormPluginBase {
       '#type' => 'tel',
       '#title' => $this->t('Enter the work phone number'),
       '#default_value' => $this->getDefaultValuesByKey('work_phone', $cardinality),
+      '#attributes' => [
+        'pattern' => "(\+?\(?\d{2,4}\)?[\d\s-]{3,})",
+      ],
     ];
 
     $form['mobile_phone'] = [
       '#type' => 'tel',
       '#title' => $this->t('Enter the mobile phone number (optional)'),
       '#default_value' => $this->getDefaultValuesByKey('mobile_phone', $cardinality),
+      '#attributes' => [
+        'pattern' => "(\+?\(?\d{2,4}\)?[\d\s-]{3,})",
+      ],
     ];
 
     // Prevent modifying of email address when un-editable.

--- a/web/modules/custom/par_forms/src/Plugin/ParForm/ParContactDetailsFullForm.php
+++ b/web/modules/custom/par_forms/src/Plugin/ParForm/ParContactDetailsFullForm.php
@@ -99,12 +99,18 @@ class ParContactDetailsFullForm extends ParFormPluginBase {
       '#type' => 'tel',
       '#title' => $this->t('Enter the work phone number'),
       '#default_value' => $this->getDefaultValuesByKey('work_phone', $cardinality),
+      '#attributes' => [
+        'pattern' => "(\+?\(?\d{2,4}\)?[\d\s-]{3,})",
+      ],
     ];
 
     $form['mobile_phone'] = [
       '#type' => 'tel',
       '#title' => $this->t('Enter the mobile phone number (optional)'),
       '#default_value' => $this->getDefaultValuesByKey('mobile_phone', $cardinality),
+      '#attributes' => [
+        'pattern' => "(\+?\(?\d{2,4}\)?[\d\s-]{3,})",
+      ],
     ];
 
     // Prevent modifying of email address when un-editable.


### PR DESCRIPTION
Enforce basic accepted phone number validation.  
prevent string on tel fields.

This format validation does not enforce the field to be required validation is only enforce on data entry.