### PR TITLE
PAR-1637: Made email a required field for all contacts

### DIFF
--- a/web/modules/custom/par_data/par_data.install
+++ b/web/modules/custom/par_data/par_data.install
@@ -1044,3 +1044,17 @@ function par_data_update_8044() {
     }
   }
 }
+
+/**
+ * PAR-1637 Update email field as required.
+ */
+function par_data_update_8045() {
+  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+
+  // New fields definitions to be updated to the par_data_person entity.
+  // @see https://www.drupal.org/node/3034742
+  $field_storage_definition = $entity_definition_update_manager->getFieldStorageDefinition('email', 'par_data_person');
+  $field_storage_definition->setRequired(TRUE);
+
+  $entity_definition_update_manager->updateFieldStorageDefinition($field_storage_definition);
+}

--- a/web/modules/custom/par_data/par_data.install
+++ b/web/modules/custom/par_data/par_data.install
@@ -1053,8 +1053,14 @@ function par_data_update_8045() {
 
   // New fields definitions to be updated to the par_data_person entity.
   // @see https://www.drupal.org/node/3034742
-  $field_storage_definition = $entity_definition_update_manager->getFieldStorageDefinition('email', 'par_data_person');
-  $field_storage_definition->setRequired(TRUE);
+  $person_field_storage_definition = $entity_definition_update_manager->getFieldStorageDefinition('email', 'par_data_person');
+  $person_field_storage_definition->setRequired(TRUE);
 
-  $entity_definition_update_manager->updateFieldStorageDefinition($field_storage_definition);
+  // New fields definitions to be updated to the par_data_person entity.
+  // @see https://www.drupal.org/node/3034742
+  $inspection_plan_field_storage_definition = $entity_definition_update_manager->getFieldStorageDefinition('summary', 'par_data_inspection_plan');
+  $inspection_plan_field_storage_definition->setRequired(FALSE);
+
+  $entity_definition_update_manager->updateFieldStorageDefinition($person_field_storage_definition);
+  $entity_definition_update_manager->updateFieldStorageDefinition($inspection_plan_field_storage_definition);
 }

--- a/web/modules/custom/par_data/src/Entity/ParDataInspectionPlan.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataInspectionPlan.php
@@ -221,7 +221,6 @@ class ParDataInspectionPlan extends ParDataEntity {
       ->setLabel(t('Inspection plan summary'))
       ->setDescription(t('Summary info for this inspection plan.'))
       ->addConstraint('par_required')
-      ->setRequired(TRUE)
       ->setRevisionable(TRUE)
       ->setSettings([
         'text_processing' => 0,

--- a/web/modules/custom/par_data/src/Entity/ParDataPerson.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataPerson.php
@@ -787,7 +787,7 @@ class ParDataPerson extends ParDataEntity implements ParDataPersonInterface {
     $fields['email'] = BaseFieldDefinition::create('string')
       ->setLabel(t('E-mail'))
       ->setDescription(t('The e-mail address of this person.'))
-      ->addConstraint('par_required')
+      ->setRequired(TRUE)
       ->addPropertyConstraints('value', [
         'Email' => ['message' => 'You must enter an email address in a valid format.'],
       ])

--- a/web/modules/custom/par_data/src/ParDataStorage.php
+++ b/web/modules/custom/par_data/src/ParDataStorage.php
@@ -99,14 +99,16 @@ class ParDataStorage extends TranceStorage {
   }
 
   /**
-   * Ensure that all Par Data Entities are valid and have all the required properties before saving.
+   * Ensure that all the required properties are validated.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    */
   public function validate(EntityInterface $entity) {
     $field_definitions = $this->entityFieldManager->getFieldDefinitions($entity->getEntityTypeId(), $entity->bundle());
     foreach ($field_definitions as $field_name => $field_definition) {
-      if ($field_definition->isRequired()
+      $storage = $field_definition->getFieldStorageDefinition();
+      // Validate all base fields that have been set as required.
+      if ($storage->isBaseField() && $field_definition->isRequired()
         && $entity->get($field_definition->getName())->isEmpty()) {
         $params = ['@field' => $field_name, '@entity' => $entity->getEntityTypeId()];
         throw new ParDataException($this->t('The field @field is required for entity @entity', $params));

--- a/web/modules/custom/par_data/tests/src/Kernel/ParDataTestBase.php
+++ b/web/modules/custom/par_data/tests/src/Kernel/ParDataTestBase.php
@@ -571,6 +571,7 @@ class ParDataTestBase extends EntityKernelTestBase {
     $values += [
       'type' => 'inspection_plan',
       'title' => 'Title for inspection plans',
+      'summary' => 'All inspection plans should have a descriptive summary.',
       'valid_date' => [
         'value' => '2016-01-01',
         'end_value' => '2018-01-01',

--- a/web/modules/custom/par_data/tests/src/Kernel/ParDataTestBase.php
+++ b/web/modules/custom/par_data/tests/src/Kernel/ParDataTestBase.php
@@ -142,6 +142,7 @@ class ParDataTestBase extends EntityKernelTestBase {
     $type = ParDataAdviceType::create([
       'id' => 'advice',
       'label' => 'Advice',
+      'advice_title' => 'Title for this advice',
     ]);
     $type->save();
 

--- a/web/modules/custom/par_data/tests/src/Kernel/ParDataTestBase.php
+++ b/web/modules/custom/par_data/tests/src/Kernel/ParDataTestBase.php
@@ -142,7 +142,6 @@ class ParDataTestBase extends EntityKernelTestBase {
     $type = ParDataAdviceType::create([
       'id' => 'advice',
       'label' => 'Advice',
-      'advice_title' => 'Title for this advice',
     ]);
     $type->save();
 
@@ -303,6 +302,7 @@ class ParDataTestBase extends EntityKernelTestBase {
     $values += [
       'type' => 'advice',
       'advice_type' => 'To Local Authority',
+      'advice_title' => 'Title for this advice',
       'notes' => $this->randomString(1000),
       'visible_authority' => TRUE,
       'visible_coordinator' => TRUE,

--- a/web/modules/custom/par_data/tests/src/Kernel/ParDataTestBase.php
+++ b/web/modules/custom/par_data/tests/src/Kernel/ParDataTestBase.php
@@ -570,6 +570,7 @@ class ParDataTestBase extends EntityKernelTestBase {
 
     $values += [
       'type' => 'inspection_plan',
+      'title' => 'Title for inspection plans',
       'valid_date' => [
         'value' => '2016-01-01',
         'end_value' => '2018-01-01',

--- a/web/modules/custom/par_data_test/content/par_data_advice/12efa979-5e8c-4144-b3bd-fa001ab4dd54.json
+++ b/web/modules/custom/par_data_test/content/par_data_advice/12efa979-5e8c-4144-b3bd-fa001ab4dd54.json
@@ -159,6 +159,11 @@
             "value": "background_information"
         }
     ],
+    "advice_title": [
+        {
+            "value": "Background information for helping friends"
+        }
+    ],
     "notes": [
         {
             "value": "Always help your friends when they are in need.",

--- a/web/modules/custom/par_data_test/content/par_data_advice/65b1f3b2-5e95-4b73-8a81-f536e6a24530.json
+++ b/web/modules/custom/par_data_test/content/par_data_advice/65b1f3b2-5e95-4b73-8a81-f536e6a24530.json
@@ -159,6 +159,11 @@
             "value": "background_information"
         }
     ],
+    "advice_title": [
+        {
+            "value": "Life coaching guide"
+        }
+    ],
     "notes": [
         {
             "value": "Cookie Monster Is The Life Coach You Never Knew You Needed. See http:\/\/bzfd.it\/2tD0DlO for more information.",

--- a/web/modules/custom/par_data_test/content/par_data_advice/a8e472b0-3853-4437-b987-263c0e054b99.json
+++ b/web/modules/custom/par_data_test/content/par_data_advice/a8e472b0-3853-4437-b987-263c0e054b99.json
@@ -159,6 +159,11 @@
             "value": "background_information"
         }
     ],
+    "advice_title": [
+        {
+            "value": "Guide for counting"
+        }
+    ],
     "notes": [
         {
             "value": "It is very important to count your numbers correctly.",


### PR DESCRIPTION
I've made the email a required field for all contacts.

@jon-edery this also will now throw an error if we try to save an entity which doesn't have all the required properties. On the whole I think this is probably a good thing, but there may be some situations where we are creating empty entities for updating later.

My thoughts on this are that if we are then that field probably shouldn't be required in the first place, and the tests should show us where this is happening. But this is a bit of a heavy handed approach. Thoughts?