### PR TITLE
PAR-1674: Accessibility fix - WCAG2.4.1 Bypass Blocks

### DIFF
--- a/web/themes/custom/par_theme/templates/page.html.twig
+++ b/web/themes/custom/par_theme/templates/page.html.twig
@@ -50,7 +50,7 @@
 
 <div id="skiplink-container">
   <div>
-    <a href="#content" class="skiplink">Skip to main content</a>
+    <a href="#block-par-theme-page-title" class="skiplink">Skip to main content</a>
   </div>
 </div>
 


### PR DESCRIPTION
This resolves issues with the skip link not linking to the main page title.