### PR TITLE
PAR-1545: Accessibility issue WCAG2.4.2 Page titled

### DIFF
--- a/web/modules/features/par_dashboards/src/Controller/ParDashboardsDashboardController.php
+++ b/web/modules/features/par_dashboards/src/Controller/ParDashboardsDashboardController.php
@@ -69,7 +69,7 @@ class ParDashboardsDashboardController extends ControllerBase {
    * {@inheritdoc}
    */
   public function titleCallback() {
-    return $this->getDefaultTitle();
+    return 'Primary Authority Register | Dashboard';
   }
 
   /**

--- a/web/themes/custom/par_theme/par_theme.libraries.yml
+++ b/web/themes/custom/par_theme/par_theme.libraries.yml
@@ -1,5 +1,5 @@
 par-kour:
-  version: 1.0
+  version: 1.1
   js:
     javascript/par.js: {}
   css:

--- a/web/themes/custom/par_theme/par_theme.theme
+++ b/web/themes/custom/par_theme/par_theme.theme
@@ -9,6 +9,20 @@ use Drupal\Core\Site\Settings;
  * @param array $variables
  */
 function par_theme_preprocess_html(array &$variables) {
+  // As per accessibility issue PAR-1545 page titles must not contain duplicate names.
+  $title_fragments = isset($variables['head_title']['title']) ? explode('|', $variables['head_title']['title']) : [];
+  $title_fragments = array_map('trim', $title_fragments);
+  $name = (string) $variables['head_title']['name'] ?? '';
+  // Remove the duplicate site name from the title.
+  $title_fragments = array_filter($title_fragments, function($value) use ($name) {
+    return $value !== $name;
+  });
+  // The second part of the title is the most important.
+  if (count($title_fragments) > 1) {
+    $secondary_title = array_shift($title_fragments);
+    array_push($title_fragments, $secondary_title);
+  }
+  $variables['head_title']['title'] = implode(' | ', $title_fragments);
 
   // Add override class to page to display PAR green branded app.
   if (Settings::get('par_branded_header_footer', FALSE)) {

--- a/web/themes/custom/par_theme/sass/par.scss
+++ b/web/themes/custom/par_theme/sass/par.scss
@@ -287,6 +287,7 @@ a.flow-link {
 fieldset, legend {
   margin: 0px;
   padding: 0px;
+  max-width: 100%;
 }
 
 .heading-medium.fieldset-legend {


### PR DESCRIPTION
This resolves issues with the dashboard page and the homepage sharing a name = 'Primary Authority Register'

We have changed the dashboard title to Dashboard. And also introduced some logic to make sure the site name 'Primary Authority Register' is a) de-prioritised in the html title tag b) no repeated in the html title tag.