### PR TITLE
PAR-1698: Automatic redirection from profile pages to dashboard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ references:
         name: web
         environment:
           APP_ENV: ci
+          SENTRY_ENVIRONMENT: ci
 
       - image: postgres:9.6.3
         environment:
@@ -66,6 +67,7 @@ references:
       command: |
         cd /tmp/workspace
         echo "{ \"build\" : \"${CIRCLE_BUILD_NUM}\", \"tag\":\"${CIRCLE_TAG}\", \"time\":\"$(date -u)\"}" > web/build_version.txt
+        echo "SENTRY_RELEASE=$CIRCLE_TAG" >> .env
         tar -zcf /tmp/$CIRCLE_TAG.tar.gz .
 
   workspace_root: &workspace_root
@@ -94,6 +96,7 @@ jobs:
             echo "S3_BUCKET_PUBLIC=$S3_BUCKET_PUBLIC" >> .env
             echo "PAR_HASH_SALT=$PAR_HASH_SALT" >> .env
             echo "APP_ENV=$APP_ENV" >> .env
+            echo "SENTRY_ENVIRONMENT=$APP_ENV" >> .env
             echo "SENTRY_DSN=$SENTRY_DSN" >> .env
             echo "SENTRY_DSN_PUBLIC=$SENTRY_DSN_PUBLIC" >> .env
             echo "PAR_GOVUK_NOTIFY_KEY=$PAR_GOVUK_NOTIFY_KEY" >> .env
@@ -278,7 +281,7 @@ jobs:
               echo "Tags can only be deployed from the master branch"
               exit 1
             else
-              ./devops/cf/push.local.sh -r -b /var/www/html/backups/${SANITISED_DATABASE}.sql -d /tmp/workspace $DEPLOY_ENV
+              ./devops/cf/push.local.sh -T $CIRCLE_TAG -r -b /var/www/html/backups/${SANITISED_DATABASE}.sql -d /tmp/workspace $DEPLOY_ENV
             fi
 
   deploy_prod:
@@ -309,7 +312,7 @@ jobs:
               echo "Tags can only be deployed from the master branch"
               exit 1
             else
-              ./devops/cf/push.local.sh -u $GOVUK_CF_USER -p $GOVUK_CF_PWD -x -d /tmp/workspace -i 4 $DEPLOY_ENV
+              ./devops/cf/push.local.sh -T $CIRCLE_TAG -u $GOVUK_CF_USER -p $GOVUK_CF_PWD -x -d /tmp/workspace -i 4 $DEPLOY_ENV
             fi
 
   deploy_test:
@@ -331,7 +334,7 @@ jobs:
           command: |
             DEPLOY_ENV=($(echo $CIRCLE_TAG | awk -F '-' '{print $1}'))
             printf "Deploying to test environment: https://beis-par-$DEPLOY_ENV.cloudapps.digital\n"
-            ./devops/cf/push.local.sh -r -b /var/www/html/backups/${SANITISED_DATABASE}.sql -d /tmp/workspace $DEPLOY_ENV
+            ./devops/cf/push.local.sh -T $CIRCLE_TAG -r -b /var/www/html/backups/${SANITISED_DATABASE}.sql -d /tmp/workspace $DEPLOY_ENV
 
   archive_database:
     <<: *defaults

--- a/sync/raven.settings.yml
+++ b/sync/raven.settings.yml
@@ -3,10 +3,10 @@ fatal_error_handler: true
 fatal_error_handler_memory: 2560
 log_levels:
   1: 1
+  2: 2
   3: 3
   4: 4
   5: 5
-  2: 0
   6: 0
   7: 0
   8: 0

--- a/web/modules/custom/par_log/par_log.info.yml
+++ b/web/modules/custom/par_log/par_log.info.yml
@@ -1,6 +1,6 @@
 name: PAR Log
 type: module
-description: Configures the audit log module for use within PAR
+description: Configures the logging for use within PAR
 core: 8.x
 package: PAR
 dependencies:

--- a/web/modules/custom/par_log/par_log.services.yml
+++ b/web/modules/custom/par_log/par_log.services.yml
@@ -4,3 +4,6 @@ services:
     tags:
       - { name: audit_log_event_subscriber }
       - { name: par_log_event_subscriber }
+  logger.channel.par:
+    parent: logger.channel_base
+    arguments: ['par']

--- a/web/modules/custom/par_login/par_login.info.yml
+++ b/web/modules/custom/par_login/par_login.info.yml
@@ -5,3 +5,4 @@ core: 8.x
 package: PAR
 dependencies:
   - locale
+  - par_log

--- a/web/modules/custom/par_login/par_login.services.yml
+++ b/web/modules/custom/par_login/par_login.services.yml
@@ -5,6 +5,6 @@ services:
       - { name: event_subscriber }
   par_login.user_redirect_subscriber:
     class: Drupal\par_login\EventSubscriber\ProfilePageRedirectSubscriber
-    arguments: ['@current_user']
+    arguments: ['@current_user', '@logger.channel.par']
     tags:
       - { name: event_subscriber }

--- a/web/modules/custom/par_login/par_login.services.yml
+++ b/web/modules/custom/par_login/par_login.services.yml
@@ -3,3 +3,8 @@ services:
     class: Drupal\par_login\Routing\ParUserRouteSubscriber
     tags:
       - { name: event_subscriber }
+  par_login.user_redirect_subscriber:
+    class: Drupal\par_login\EventSubscriber\ProfilePageRedirectSubscriber
+    arguments: ['@current_user']
+    tags:
+      - { name: event_subscriber }

--- a/web/modules/custom/par_login/src/EventSubscriber/ProfilePageRedirectSubscriber.php
+++ b/web/modules/custom/par_login/src/EventSubscriber/ProfilePageRedirectSubscriber.php
@@ -64,7 +64,8 @@ class ProfilePageRedirectSubscriber implements EventSubscriberInterface {
 
     // Compare the page routes and redirect users without permission
     // to view their profile pages.
-    if (!$this->account->hasPermission('administer users') &&
+    if ($this->account->isAuthenticated() && $profile_page &&
+      !$this->account->hasPermission('administer users') &&
       ltrim($request->getPathInfo(), '/') === ltrim($profile_page->getInternalPath(), '/')) {
 
       // Log the denied request as well as the referer for information.

--- a/web/modules/custom/par_login/src/EventSubscriber/ProfilePageRedirectSubscriber.php
+++ b/web/modules/custom/par_login/src/EventSubscriber/ProfilePageRedirectSubscriber.php
@@ -4,6 +4,7 @@ namespace Drupal\par_login\EventSubscriber;
 
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -19,13 +20,23 @@ class ProfilePageRedirectSubscriber implements EventSubscriberInterface {
   private $account;
 
   /**
+   * The logger service.
+   *
+   * @param \Psr\Log\LoggerInterface $logger
+   */
+  private $logger;
+
+  /**
    * @param \Drupal\Core\Session\AccountProxyInterface $account
    *   The current user.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger service.
    *
    * @throws \InvalidArgumentException
    */
-  public function __construct(AccountProxyInterface $account) {
+  public function __construct(AccountProxyInterface $account, LoggerInterface $logger) {
     $this->account = $account;
+    $this->logger = $logger;
   }
 
   /**
@@ -55,6 +66,13 @@ class ProfilePageRedirectSubscriber implements EventSubscriberInterface {
     // to view their profile pages.
     if (!$this->account->hasPermission('administer users') &&
       ltrim($request->getPathInfo(), '/') === ltrim($profile_page->getInternalPath(), '/')) {
+
+      // Log the denied request as well as the referer for information.
+      $referer = $request->headers->get('referer');
+      $this->logger->warning(
+        'User @user is not allowed to access their profile page. Redirected from %redirected',
+        ['%user' => $this->account->id(), '%redirected' => $referer]
+      );
 
       $redirect_url = Url::fromRoute('par_dashboards.dashboard');
       $response = new RedirectResponse($redirect_url->toString(), 301);

--- a/web/modules/custom/par_login/src/EventSubscriber/ProfilePageRedirectSubscriber.php
+++ b/web/modules/custom/par_login/src/EventSubscriber/ProfilePageRedirectSubscriber.php
@@ -74,9 +74,18 @@ class ProfilePageRedirectSubscriber implements EventSubscriberInterface {
         ['%user' => $this->account->id(), '%redirected' => $referer]
       );
 
-      $redirect_url = Url::fromRoute('par_dashboards.dashboard');
-      $response = new RedirectResponse($redirect_url->toString(), 301);
-      $event->setResponse($response);
+      // Determine which dashboard the user should be directed to.
+      if ($this->account->hasPermission('access helpdesk')) {
+        $dashboard = 'par_help_desks_flows.helpdesk_dashboard';
+      }
+      else if ($this->account->hasPermission('access par dashboard')) {
+        $dashboard = 'par_dashboards.dashboard';
+      }
+      if (isset($dashboard)) {
+        $redirect_url = Url::fromRoute($dashboard);
+        $response = new RedirectResponse($redirect_url->toString(), 301);
+        $event->setResponse($response);
+      }
     }
   }
 

--- a/web/modules/custom/par_login/src/EventSubscriber/ProfilePageRedirectSubscriber.php
+++ b/web/modules/custom/par_login/src/EventSubscriber/ProfilePageRedirectSubscriber.php
@@ -32,9 +32,9 @@ class ProfilePageRedirectSubscriber implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {
-    // This needs to run before RouterListener::onKernelRequest(), to ensure
-    // the correct route is resolved.
-    $events[KernelEvents::REQUEST][] = ['redirectProfilePage', 33];
+    // This MUST run before RouterListener::onKernelRequest(), to ensure
+    // the redirection doesn't recursively resolve.
+    $events[KernelEvents::REQUEST][] = ['redirectProfilePage', 34];
     return $events;
   }
 

--- a/web/modules/custom/par_login/src/Routing/ParUserRouteSubscriber.php
+++ b/web/modules/custom/par_login/src/Routing/ParUserRouteSubscriber.php
@@ -14,7 +14,6 @@ class ParUserRouteSubscriber extends RouteSubscriberBase {
    * {@inheritdoc}
    */
   protected function alterRoutes(RouteCollection $collection) {
-
     // View user
     if ($route = $collection->get('entity.user.canonical')) {
       $route->setRequirement('_permission', 'administer users');

--- a/web/modules/custom/par_login/src/Routing/ParUserRouteSubscriber.php
+++ b/web/modules/custom/par_login/src/Routing/ParUserRouteSubscriber.php
@@ -14,7 +14,7 @@ class ParUserRouteSubscriber extends RouteSubscriberBase {
    * {@inheritdoc}
    */
   protected function alterRoutes(RouteCollection $collection) {
-    // View user
+    // Require higher privileges to view the user profile page.
     if ($route = $collection->get('entity.user.canonical')) {
       $route->setRequirement('_permission', 'administer users');
     }


### PR DESCRIPTION
Added automatic redirection of users from _their_ profile pages to the dashboard.

Added improved logging to track down why they were directed to their profile page in the first place.

According to the login_destination rule 'dashboard' all authenticated users should be redirected to the dashboard after 'login' and 'one-time-login'... I guess it's possible this isn't working all the time, or that the invite system is logging people in in a different way, or perhaps there's some other bug in it. It would be good to test every single way of logging into the system.