### PR TITLE
Par 1906 user able to add duplicate legal entity after reinstating

### DIFF
--- a/web/modules/custom/par_data/src/Entity/ParDataPartnership.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataPartnership.php
@@ -675,6 +675,9 @@ class ParDataPartnership extends ParDataEntity {
   /**
    * Get partnership legal entities for this partnership.
    *
+   * @param boolean $active
+   *  If TRUE then only active PLEs are returned. Default FALSE.
+   *
    * @return ParDataPartnershipLegalEntity[]
    */
   public function getPartnershipLegalEntities($active = FALSE) {

--- a/web/modules/custom/par_data/src/Entity/ParDataPartnershipLegalEntity.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataPartnershipLegalEntity.php
@@ -3,6 +3,7 @@
 namespace Drupal\par_data\Entity;
 
 use Drupal\Component\Datetime\DateTimePlus;
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
@@ -233,6 +234,26 @@ class ParDataPartnershipLegalEntity extends ParDataEntity {
     return (!$partnership
         || !$partnership->isActive()
         || $this->getStartDate() > $now->modify('-1 day'));
+  }
+
+  /**
+   * Check whether this partnership legal entity can be reinstated.
+   *
+   * A partnership legal entity can not be reinstated if there already exists another active partnership legal entity
+   * for the same legal entity.
+   *
+   * @return bool
+   *   TRUE if the legal entity can be reinstated.
+   */
+  public function isReinstatable() {
+
+    foreach ($this->getPartnership()->getPartnershipLegalEntities(TRUE) as $active_partnership_le) {
+      if ($this->getLegalEntity()->id() == $active_partnership_le->getLegalEntity()->id()) {
+        return FALSE;
+      }
+    }
+
+    return TRUE;
   }
 
   /**

--- a/web/modules/custom/par_data/src/Entity/ParDataPartnershipLegalEntity.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataPartnershipLegalEntity.php
@@ -239,13 +239,18 @@ class ParDataPartnershipLegalEntity extends ParDataEntity {
   /**
    * Check whether this partnership legal entity can be reinstated.
    *
-   * A partnership legal entity can not be reinstated if there already exists another active partnership legal entity
-   * for the same legal entity.
+   * A partnership legal entity can be reinstated if:
+   *  - It has been revoked
+   *  - There is not already existent another active partnership legal entity for the same legal entity.
    *
    * @return bool
    *   TRUE if the legal entity can be reinstated.
    */
   public function isReinstatable() {
+
+    if (!$this->isRevoked()) {
+      return FALSE;
+    }
 
     foreach ($this->getPartnership()->getPartnershipLegalEntities(TRUE) as $active_partnership_le) {
       if ($this->getLegalEntity()->id() == $active_partnership_le->getLegalEntity()->id()) {

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsLegalEntityReinstateForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsLegalEntityReinstateForm.php
@@ -64,6 +64,14 @@ class ParPartnershipFlowsLegalEntityReInstateForm extends ParBaseForm {
       $this->accessResult = AccessResult::forbidden('This legal entity is already active.');
     }
 
+    // We can't reinstate a PLE if there is already an active PLE for the same LE.
+    foreach ($par_data_partnership->getPartnershipLegalEntities(TRUE) as $active_partnership_le) {
+      if ($par_data_partnership_le->getLegalEntity()->id() == $active_partnership_le->getLegalEntity()->id()) {
+        $this->accessResult = AccessResult::forbidden('Another instance of this legal entity is already active.');
+        break;
+      }
+    }
+
     return parent::accessCallback($route, $route_match, $account);
   }
 
@@ -121,6 +129,28 @@ class ParPartnershipFlowsLegalEntityReInstateForm extends ParBaseForm {
     $this->addCacheableDependency($par_data_partnership_le);
 
     return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * Validate the form to make sure the correct values have been entered.
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+
+    // Get the partnership and PLE being reinstated.
+    /* @var ParDataPartnership $partnership */
+    $partnership = $this->getFlowDataHandler()->getParameter('par_data_partnership');
+    /* @var ParDataPartnershipLegalEntity $partnership_legal_entity */
+    $partnership_legal_entity = $this->getFlowDataHandler()->getParameter('par_data_partnership_le');
+
+    // We can't reinstate a PLE if there is already an active PLE for the same LE.
+    foreach ($partnership->getPartnershipLegalEntities(TRUE) as $active_partnership_le) {
+      if ($partnership_legal_entity->getLegalEntity()->id() == $active_partnership_le->getLegalEntity()->id()) {
+        $id = $this->getElementId(['registered_number'], $form);
+        $form_state->setErrorByName($this->getElementName('registered_number'), $this->wrapErrorMessage('This legal entity is already an active participant in the partnership.', $id));
+        break;
+      }
+    }
   }
 
   /**

--- a/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsLegalEntityReinstateForm.php
+++ b/web/modules/features/par_partnership_flows/src/Form/ParPartnershipFlowsLegalEntityReinstateForm.php
@@ -65,11 +65,8 @@ class ParPartnershipFlowsLegalEntityReInstateForm extends ParBaseForm {
     }
 
     // We can't reinstate a PLE if there is already an active PLE for the same LE.
-    foreach ($par_data_partnership->getPartnershipLegalEntities(TRUE) as $active_partnership_le) {
-      if ($par_data_partnership_le->getLegalEntity()->id() == $active_partnership_le->getLegalEntity()->id()) {
-        $this->accessResult = AccessResult::forbidden('Another instance of this legal entity is already active.');
-        break;
-      }
+    if (!$par_data_partnership_le->isReinstatable()) {
+      $this->accessResult = AccessResult::forbidden('Another instance of this legal entity is already active.');
     }
 
     return parent::accessCallback($route, $route_match, $account);
@@ -137,19 +134,13 @@ class ParPartnershipFlowsLegalEntityReInstateForm extends ParBaseForm {
   public function validateForm(array &$form, FormStateInterface $form_state) {
     parent::validateForm($form, $form_state);
 
-    // Get the partnership and PLE being reinstated.
-    /* @var ParDataPartnership $partnership */
-    $partnership = $this->getFlowDataHandler()->getParameter('par_data_partnership');
     /* @var ParDataPartnershipLegalEntity $partnership_legal_entity */
     $partnership_legal_entity = $this->getFlowDataHandler()->getParameter('par_data_partnership_le');
 
     // We can't reinstate a PLE if there is already an active PLE for the same LE.
-    foreach ($partnership->getPartnershipLegalEntities(TRUE) as $active_partnership_le) {
-      if ($partnership_legal_entity->getLegalEntity()->id() == $active_partnership_le->getLegalEntity()->id()) {
-        $id = $this->getElementId(['registered_number'], $form);
-        $form_state->setErrorByName($this->getElementName('registered_number'), $this->wrapErrorMessage('This legal entity is already an active participant in the partnership.', $id));
-        break;
-      }
+    if (!$partnership_legal_entity->isReinstatable()) {
+      $id = $this->getElementId(['registered_number'], $form);
+      $form_state->setErrorByName($this->getElementName('registered_number'), $this->wrapErrorMessage('This legal entity is already an active participant in the partnership.', $id));
     }
   }
 


### PR DESCRIPTION
Partnership legal entity reinstate form can no longer be accessed if the PLE can not be reinstated.

Add validation to partnership legal entity reinstate form to double check that reinstating is OK.