### PR TITLE
PAR-2149: Removed permissions restrictions on who can receive notifications

### DIFF
--- a/web/modules/custom/par_notification/src/ParRecipient.php
+++ b/web/modules/custom/par_notification/src/ParRecipient.php
@@ -35,7 +35,7 @@ class ParRecipient {
    * Constructs an instance of a PAR Recipient class.
    *
    * @param ?EntityInterface $entity
-   *   The related entity.
+   *   The related entity, usually a user or contact record.
    */
   public function __construct(string $email, string $name = NULL, EntityInterface $entity = NULL) {
     $this->email = $email;

--- a/web/modules/custom/par_notification/src/ParSubscriptionManager.php
+++ b/web/modules/custom/par_notification/src/ParSubscriptionManager.php
@@ -214,12 +214,6 @@ class ParSubscriptionManager extends DefaultPluginManager implements ParSubscrip
         $current_user->getEmail() != $recipient->getEmail();
     });
 
-    // Only allow users (including anonymous) who have the permission to see this message.
-    $permission = "receive {$message->getTemplate()->id()} notification";
-    $recipients = array_filter($recipients, function ($recipient) use ($permission) {
-      return $recipient->getAccount()->hasPermission($permission);
-    });
-
     // Compare the ParRecipient instances using string representation.
     return array_unique($recipients, SORT_STRING);
   }


### PR DESCRIPTION
Remove the permission filter on subscribed recipients, we introduced a check so that email addresses that did not have user accounts could not receive notifications about sensitive data in PAR.

We've not removed this restriction again following user feedback and an evaluation that some users have notifications sent to a shared inbox, but then sign in using a personal email address when they click the notification link.