### PR TITLE
PAR-2269 

### DIFF
--- a/tests/e2e/par-test-automation/src/main/java/uk/gov/beis/pageobjects/AdviceNoticeDetailsPage.java
+++ b/tests/e2e/par-test-automation/src/main/java/uk/gov/beis/pageobjects/AdviceNoticeDetailsPage.java
@@ -9,42 +9,46 @@ import org.openqa.selenium.support.PageFactory;
 
 public class AdviceNoticeDetailsPage extends BasePageObject {
 
+	@FindBy(id = "edit-advice-title")
+	private WebElement title;
+	
+	@FindBy(id = "edit-notes")
+	private WebElement descriptionBox;
+	
+	@FindBy(id = "edit-save")
+	private WebElement saveBtn;
+
+	private String advicetype = "//label[contains(text(),'?')]";
+	private String regfunc = "//label[contains(text(),'?')]";
+	
 	public AdviceNoticeDetailsPage() throws ClassNotFoundException, IOException {
 		super();
 	}
 
-	@FindBy(xpath = "//div[@class='govuk-form-group']/textarea")
-	WebElement descriptionBox;
-
-	@FindBy(xpath = "//input[contains(@value,'Save')]")
-	WebElement saveBtn;
-
-	@FindBy(id = "edit-advice-title")
-	WebElement title;
-
-	private String advicetype = "//label[contains(text(),'?')]";
-	private String regfunc = "//label[contains(text(),'?')]";
-
-	public AdviceNoticeDetailsPage selectAdviceType(String type) {
-		driver.findElement(By.xpath(advicetype.replace("?", type))).click();
-		return PageFactory.initElements(driver, AdviceNoticeDetailsPage.class);
-	}
-
-	public AdviceNoticeDetailsPage selectRegFunc(String func) {
-		driver.findElement(By.xpath(regfunc.replace("?", func))).click();
-		return PageFactory.initElements(driver, AdviceNoticeDetailsPage.class);
-	}
-
-	public AdviceNoticeDetailsPage enterTitle(String value) {
+	public void enterTitle(String value) {
 		title.clear();
 		title.sendKeys(value);
-		return PageFactory.initElements(driver, AdviceNoticeDetailsPage.class);
+	}
+	
+	public void selectAdviceType(String type) {
+		WebElement adviceType = driver.findElement(By.xpath(advicetype.replace("?", type)));
+		
+		if(!adviceType.isSelected()) {
+			adviceType.click();
+		}
 	}
 
-	public AdviceNoticeDetailsPage enterDescription(String description) throws Throwable {
+	public void selectRegFunc(String func) {
+		WebElement regulatoryFunctions = driver.findElement(By.xpath(regfunc.replace("?", func)));
+		
+		if(!regulatoryFunctions.isSelected()) {
+			regulatoryFunctions.click();
+		}
+	}
+
+	public void enterDescription(String description) throws Throwable {
 		descriptionBox.clear();
 		descriptionBox.sendKeys(description);
-		return PageFactory.initElements(driver, AdviceNoticeDetailsPage.class);
 	}
 
 	public InspectionPlanExpirationPage save() {
@@ -52,4 +56,8 @@ public class AdviceNoticeDetailsPage extends BasePageObject {
 		return PageFactory.initElements(driver, InspectionPlanExpirationPage.class);
 	}
 
+	public AdviceNoticeSearchPage clickSave() {
+		saveBtn.click();
+		return PageFactory.initElements(driver, AdviceNoticeSearchPage.class);
+	}
 }

--- a/tests/e2e/par-test-automation/src/main/java/uk/gov/beis/pageobjects/AdviceNoticeSearchPage.java
+++ b/tests/e2e/par-test-automation/src/main/java/uk/gov/beis/pageobjects/AdviceNoticeSearchPage.java
@@ -12,29 +12,56 @@ import uk.gov.beis.utility.DataStore;
 
 public class AdviceNoticeSearchPage extends BasePageObject {
 
+	@FindBy(id = "edit-keywords")
+	private WebElement adviceSearchBar;
+	
+	@FindBy(id = "edit-submit-advice-lists")
+	private WebElement searchBtn;
+	
+	@FindBy(linkText = "Upload advice")
+	private WebElement uploadBtn;
+	
+	String planstatus = "//td/a[contains(text(),'?')]/parent::td/following-sibling::td[2]";
+	
 	public AdviceNoticeSearchPage() throws ClassNotFoundException, IOException {
 		super();
 	}
 
-	@FindBy(linkText = "Upload advice")
-	WebElement uploadBtn;
-
+	public AdviceNoticeSearchPage searchForAdvice(String title) {
+		adviceSearchBar.clear();
+		adviceSearchBar.sendKeys(title);
+		
+		searchBtn.click();
+		return PageFactory.initElements(driver, AdviceNoticeSearchPage.class);
+	}
+	
 	public UploadAdviceNoticePage selectUploadLink() {
 		uploadBtn.click();
 		return PageFactory.initElements(driver, UploadAdviceNoticePage.class);
 	}
-
-	String planstatus = "//td/a[contains(text(),'?')]/parent::td/following-sibling::td[2]";
-
+	
+	public AdviceNoticeDetailsPage selectEditAdviceButton() {
+		
+		WebElement editLink = driver.findElement(By.partialLinkText("Edit"));
+		
+		editLink.click();
+		return PageFactory.initElements(driver, AdviceNoticeDetailsPage.class);
+	}
+	
+	public AdviceNoticeDetailsPage selectArchiveAdviceButton() {
+		
+		WebElement editLink = driver.findElement(By.partialLinkText("Archive"));
+		
+		editLink.click();
+		return PageFactory.initElements(driver, AdviceNoticeDetailsPage.class);
+	}
+	
 	public String getAdviceStatus() {
+		
 		try {
-			return driver
-					.findElement(
-							By.xpath(planstatus.replace("?", DataStore.getSavedValue(UsableValues.ADVICENOTICE_TITLE))))
-					.getText();
+			return driver.findElement(By.xpath(planstatus.replace("?", DataStore.getSavedValue(UsableValues.ADVICENOTICE_TITLE)))).getText();
 		} catch (Exception e) {
 			return ("No results returned");
 		}
 	}
-
 }

--- a/tests/e2e/par-test-automation/src/main/java/uk/gov/beis/pageobjects/ArchivePage.java
+++ b/tests/e2e/par-test-automation/src/main/java/uk/gov/beis/pageobjects/ArchivePage.java
@@ -1,0 +1,28 @@
+package uk.gov.beis.pageobjects;
+
+import java.io.IOException;
+
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+
+public class ArchivePage extends BasePageObject {
+	
+	@FindBy(id = "edit-archive-reason")
+	private WebElement archiveReasonBox;
+	
+	@FindBy(id = "edit-save")
+	private WebElement saveBtn;
+	
+	public ArchivePage() throws ClassNotFoundException, IOException {
+		super();
+	}
+	
+	public AdviceNoticeSearchPage enterReasonForArchiving(String reason) {
+		archiveReasonBox.clear();
+		archiveReasonBox.sendKeys(reason);
+		
+		saveBtn.click();
+		return PageFactory.initElements(driver, AdviceNoticeSearchPage.class);
+	}
+}

--- a/tests/e2e/par-test-automation/src/main/java/uk/gov/beis/stepdefs/PARStepDefs.java
+++ b/tests/e2e/par-test-automation/src/main/java/uk/gov/beis/stepdefs/PARStepDefs.java
@@ -105,7 +105,8 @@ public class PARStepDefs {
 	private InspectionFeedbackCompletionPage inspectionFeedbackCompletionPage;
 	private ViewEnquiryPage viewEnquiryPage;
 	private EditRegisteredAddressPage editRegisteredAddressPage;
-
+	private ArchivePage archivePage;
+	
 	// PAR News Letter
 	private UserProfilePage userProfilePage;
 	private UpdateUserCommunicationPreferencesPage updateUserCommunicationPreferencesPage;
@@ -218,7 +219,8 @@ public class PARStepDefs {
 		viewEnquiryPage = PageFactory.initElements(driver, ViewEnquiryPage.class);
 		editRegisteredAddressPage = PageFactory.initElements(driver, EditRegisteredAddressPage.class);
 		legalEntityTypePage = PageFactory.initElements(driver, LegalEntityTypePage.class);
-
+		archivePage = PageFactory.initElements(driver, ArchivePage.class);
+		
 		// PAR News Letter
 		userProfilePage = PageFactory.initElements(driver, UserProfilePage.class);
 		updateUserCommunicationPreferencesPage = PageFactory.initElements(driver,
@@ -818,9 +820,6 @@ public class PARStepDefs {
 		adviceNoticeDetailsPage.selectRegFunc(DataStore.getSavedValue(UsableValues.ADVICENOTICE_REGFUNCTION));
 		adviceNoticeDetailsPage.enterDescription(DataStore.getSavedValue(UsableValues.ADVICENOTICE_DESCRIPTION));
 		adviceNoticeDetailsPage.save();
-		
-		LOG.info("Check advice notice status is set to \"Active\"");
-		Assert.assertTrue("Failed: Status not set to \"Active\"", adviceNoticeSearchPage.getAdviceStatus().equalsIgnoreCase("Active"));
 	}
 
 	@When("^the user uploads an advice plan against the partnership with the following details:$")
@@ -1654,5 +1653,58 @@ public class PARStepDefs {
 	public void the_new_Organisation_contact_is_removed_Successfully() throws Throwable {
 		LOG.info("Verifying the new Authority contact was removed successfully.");
 		assertTrue("Contact was not Removed.", parPartnershipConfirmationPage.checkContactExists());
+	}
+	
+	@Then("^the advice notice it uploaded successfully and set to active$")
+	public void the_advice_notice_it_uploaded_successfully_and_set_to_active() throws Throwable {
+		LOG.info("Checking Advice notice status is set to \"Active\"");
+		Assert.assertTrue("Failed: Status not set to \"Active\"", adviceNoticeSearchPage.getAdviceStatus().equalsIgnoreCase("Active"));
+	}
+
+	@When("^the user selects the edit advice action link$")
+	public void the_user_selects_the_edit_advice_action_link() throws Throwable {
+		LOG.info("Searching for the newly added Advice notice.");
+		
+		adviceNoticeSearchPage.searchForAdvice(DataStore.getSavedValue(UsableValues.ADVICENOTICE_TITLE));
+		adviceNoticeSearchPage.selectEditAdviceButton();
+	}
+
+	@When("^the user edits the advice notice with the following details:$")
+	public void the_user_edits_the_advice_notice_with_the_following_details(DataTable details) throws Throwable {
+		LOG.info("Editing Advice notice details.");
+		
+		for (Map<String, String> data : details.asMaps(String.class, String.class)) {
+			
+			DataStore.saveValue(UsableValues.ADVICENOTICE_TITLE, data.get("Title"));
+			DataStore.saveValue(UsableValues.ADVICENOTICE_TYPE, data.get("Type of Advice"));
+			DataStore.saveValue(UsableValues.ADVICENOTICE_DESCRIPTION, data.get("Description"));
+		}
+		
+		adviceNoticeDetailsPage.enterTitle(DataStore.getSavedValue(UsableValues.ADVICENOTICE_TITLE));
+		adviceNoticeDetailsPage.selectAdviceType(DataStore.getSavedValue(UsableValues.ADVICENOTICE_TYPE));
+		adviceNoticeDetailsPage.enterDescription(DataStore.getSavedValue(UsableValues.ADVICENOTICE_DESCRIPTION));
+		adviceNoticeDetailsPage.clickSave();
+	}
+
+	@Then("^the advice notice it updated successfully$")
+	public void the_advice_notice_it_updated_successfully() throws Throwable {
+		LOG.info("Checking Advice notice status is set to \"Active\"");
+		Assert.assertTrue("Failed: Status not set to \"Active\"", adviceNoticeSearchPage.getAdviceStatus().equalsIgnoreCase("Active"));
+	}
+
+	@When("^the user archives the advice notice with the following reason \"([^\"]*)\"$")
+	public void the_user_archives_the_advice_notice_with_the_following_reason(String reason) throws Throwable {
+		LOG.info("Archiving Advice Notice.");
+		
+		adviceNoticeSearchPage.searchForAdvice(DataStore.getSavedValue(UsableValues.ADVICENOTICE_TITLE));
+		adviceNoticeSearchPage.selectArchiveAdviceButton();
+		
+		archivePage.enterReasonForArchiving(reason);
+	}
+
+	@Then("^the advice notice is archived successfully$")
+	public void the_advice_notice_is_archived_successfully() throws Throwable {
+		LOG.info("Check Advice notice status is set to \"Archived\"");
+		Assert.assertTrue("Failed: Status not set to \"Archived\"", adviceNoticeSearchPage.getAdviceStatus().equalsIgnoreCase("Archived"));
 	}
 }

--- a/tests/e2e/par-test-automation/src/test/resources/features/PAR-General.feature
+++ b/tests/e2e/par-test-automation/src/test/resources/features/PAR-General.feature
@@ -72,7 +72,7 @@ Feature: General
       | Title | WorkNumber  | MobileNumber | ContactNotes              |
       | Dr    | 01706553019 |  07356001870 | Test contact note update. |
     Then the new Primary Authority contact is updated Successfully
-    # Update the new contact
+    # Remove the new contact
     When the user removes the new Primary Authority contact
     Then the new Primary Authority contact is removed Successfully
 
@@ -90,7 +90,7 @@ Feature: General
       | Title | WorkNumber  | MobileNumber | ContactNotes              |
       | Dr    | 01706553019 |  07356001143 | Test contact note update. |
     Then the new Organisation contact is updated Successfully
-    # Update the new contact
+    # Remove the new contact
     When the user removes the new Organisation contact
     Then the new Organisation contact is removed Successfully
 
@@ -114,6 +114,24 @@ Feature: General
     Then the inspection plan is updated correctly
 
   @regression @advicenotice
+  Scenario: Verify Upload, Update and Archive of an Advice Notice (Happy Path - PAR-1874, PAR-1875)
+    Given the user is on the PAR login page
+    And the user logs in with the "par_helpdesk@example.com" user credentials
+    When the user searches for the last created partnership
+    And the user uploads an advice notice against the partnership with the following details:
+      | Title              | Type of Advice         | Reg Function   | Description         |
+      | Partnership Advice | Background information | Cookie control | Advice description. |
+    Then the advice notice it uploaded successfully and set to active
+    When the user selects the edit advice action link
+    And the user edits the advice notice with the following details:
+      | Title                     | Type of Advice                                | Description                |
+      | Partnership Advice Update | Primary Authority advice for the organisation | Advice description update. |
+    Then the advice notice it updated successfully
+    When the user archives the advice notice with the following reason "Advice Complete"
+    Then the advice notice is archived successfully
+
+  # Upload and Remove Advice Test goes here.
+  @regression @advicenotice
   Scenario: Verify Upload of Advice Notice (Happy Path - PAR-1873)
     Given the user is on the PAR login page
     And the user logs in with the "par_helpdesk@example.com" user credentials
@@ -121,9 +139,8 @@ Feature: General
     And the user uploads an advice notice against the partnership with the following details:
       | Title          | Type of Advice         | Reg Function   | Description |
       | Advice Title 1 | Background information | Cookie control | Test Advice |
+    Then the advice notice it uploaded successfully and set to active
 
-  # Update and Archive Advice Test goes here.
-  # Upload and Remove Advice Test goes here.
   @regression @enforcement
   Scenario: Verify Send Notification of Proposed Enforcement, Approval and Removal (Happy Path - PAR-1852, PAR-1853, PAR-1854)
     Given the user is on the PAR login page
@@ -271,7 +288,6 @@ Feature: General
     And the user logs in with the "par_authority@example.com" user credentials
     When the user searches for the last created partnership
 
-  # Nominate the Co-ordinated Partnership Test goes here. (This step is imprtant for other tests such as searching the Puplic registry, PAR-2079)
   @regression @partnershipapplication @coordinated
   Scenario: Successfully Nominate a Coordinated Partnership (Happy Path - PAR-2261)
     Given the user is on the PAR login page


### PR DESCRIPTION
Added test to Add, Update and Archive an Advice notice for a partnership. 
Moved the Assertion check for the upload of an Advice notice test into a Then step definition.